### PR TITLE
Make attache-init create new attache profile, fixes #14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+profiles

--- a/lib/attache
+++ b/lib/attache
@@ -47,23 +47,15 @@ else
 fi
 export ATTACHE_ROOT
 
-## I have a suspicion that this variable is totally irrelevant to
-## attache.  I think it is used by rbenv for figuring out what to do
-## about the current local dir, because it supports local gem installs
-## (I think!)
-## TODO: investigate whether this is useful or just confusing and
-## unnecessary
-if [ -z "${ATTACHE_DIR}" ]; then
-  ATTACHE_DIR="$(pwd)"
-else
-  cd "$ATTACHE_DIR" 2>/dev/null || {
-    echo "attache: cannot change working directory to \`$ATTACHE_DIR'"
-    exit 1
-  } >&2
-  ATTACHE_DIR="$(pwd)"
-  cd "$OLDPWD"
+if [ -z "${ATTACHE_PROFILE}" ]; then
+  ATTACHE_PROFILE="${ATTACHE_ROOT}/profiles/default"
 fi
-export ATTACHE_DIR
+export ATTACHE_PROFILE
+
+if [ -z "${SECRETS_SUFFIX}" ]; then
+  SECRETS_SUFFIX=".attache_secrets"
+fi
+export SECRETS_SUFFIX
 
 shopt -s nullglob
 

--- a/lib/attache-init
+++ b/lib/attache-init
@@ -23,18 +23,18 @@
 set -e
 [ -n "$ATTACHE_DEBUG" ] && set -x
 
-[ -d $ATTACHE_DIR ] && echo "The folder $ATTACHE_DIR already exists!
-Maybe you should change your ATTACHE_DIR environment variable..." && exit 1
+[ -d $ATTACHE_PROFILE ] && echo "The directory $ATTACHE_PROFILE already exists!
+Maybe you should change your ATTACHE_PROFILE environment variable..." && exit 1
 
-mkdir -p $ATTACHE_DIR
+mkdir -p $ATTACHE_PROFILE
 
-pushd $ATTACHE_DIR >/dev/null 2>/dev/null
+pushd $ATTACHE_PROFILE >/dev/null 2>/dev/null
 
 git init
-echo "*$SECRETS_SUFFIX" > .gitignore
+echo "*${SECRETS_SUFFIX}" > .gitignore
 git add .gitignore
 git commit -m "Initial commit"
 
 popd >/dev/null 2>/dev/null
 
-echo "Congratulations! You now have a brand new attache located at $ATTACHE_DIR"
+echo "Congratulations! You now have a brand new attache located at $ATTACHE_PROFILE"


### PR DESCRIPTION
Add .gitignore for profiles. Modify lib/attache and lib/attache-init to
support new environment variable ATTACHE_PROFILE.
