### PR TITLE
Fix #119. Prep package for https://crates.io.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "hermit"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "clap 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "hermit"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Geoff Shannon <geoffpshannon@gmail.com>",
            "Reilly Tucker Siemens <reilly.siemens@gmail.com>",
            "Joe Houng <sjhoung@gmail.com>",
            "Aaron Griffin <aig787@gmail.com>"]
+description = "A home directory configuration management assistant."
+homepage = "https://bike-barn.github.io/hermit"
+repository = "https://github.com/bike-barn/hermit"
+readme = "README.md"
+keywords = ["home", "directory", "configuration", "management", "dotfiles"]
+license = "GPL-3.0"
 
 [dependencies]
 clap = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,15 @@
 extern crate clap;
 
 fn main() {
+
+    let version = format!("{}.{}.{}{}",
+                          option_env!("CARGO_PKG_VERSION_MAJOR").unwrap_or("X"),
+                          option_env!("CARGO_PKG_VERSION_MINOR").unwrap_or("X"),
+                          option_env!("CARGO_PKG_VERSION_PATCH").unwrap_or("X"),
+                          option_env!("CARGO_PKG_VERSION_PRE").unwrap_or(""));
+
     let app = clap_app!(myapp =>
-        (version: "0.1.0")
+        (version: &*version)
         (author: "Bike Barn <https://github.com/bike-barn/hermit>")
         (about: "A home directory configuration management assistant.")
         (@subcommand add =>

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,30 +44,30 @@ fn main() {
     match app_matches.subcommand() {
         ("add", Some(matches)) => {
             println!("hermit add is not yet implemented");
-        },
+        }
         ("clone", Some(matches)) => {
             println!("hermit clone is not yet implemented");
-        },
+        }
         ("doctor", Some(matches)) => {
             println!("hermit doctor is not yet implemented");
-        },
+        }
         ("git", Some(matches)) => {
             println!("hermit git is not yet implemented");
-        },
+        }
         ("init", Some(matches)) => {
             println!("hermit init is not yet implemented");
-        },
+        }
         ("nuke", Some(matches)) => {
             println!("hermit nuke is not yet implemented");
-        },
+        }
         ("status", Some(matches)) => {
             println!("hermit status is not yet implemented");
-        },
+        }
         ("use", Some(matches)) => {
             println!("hermit use is not yet implemented");
-        },
+        }
         _ => {
             println!("no subcommand was called");
-        },
+        }
     }
 }


### PR DESCRIPTION
Downgrade version from 0.1.0 to 0.0.1. Run cargo fmt against
src/main.rs and upgrade it with the ability to pull version information
from Cargo.toml itself.