### PR TITLE
Implement a filesystem configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,12 +14,12 @@ pub trait Config {
 }
 
 #[derive(Clone)]
-pub struct FilesystemConfig {
+pub struct FsConfig {
     pub root_path: PathBuf,
     pub current_shell: String,
 }
 
-impl FilesystemConfig {
+impl FsConfig {
     fn new(root_path: PathBuf) -> Result<Self, io::Error> {
         let config_path = root_path.join("current_shell");
         let config_display = config_path.display();
@@ -29,14 +29,14 @@ impl FilesystemConfig {
 
         try!(file.read_to_string(&mut current_shell));
 
-        Ok(FilesystemConfig {
+        Ok(FsConfig {
             root_path: root_path,
             current_shell: current_shell,
         })
     }
 }
 
-impl Config for FilesystemConfig {
+impl Config for FsConfig {
     fn root_path(&self) -> &PathBuf {
         &self.root_path
     }
@@ -105,7 +105,7 @@ mod test {
     use std::fs::File;
     use std::path::PathBuf;
     use std::io::prelude::*;
-    use super::{Config, FilesystemConfig};
+    use super::{Config, FsConfig};
 
     fn clean_up(test_root: &PathBuf) {
         if test_root.exists() {
@@ -131,7 +131,7 @@ mod test {
     #[test]
     fn has_a_root_path() {
         let test_root = set_up("root-path", "default");
-        let config = FilesystemConfig::new(test_root.clone()).unwrap();
+        let config = FsConfig::new(test_root.clone()).unwrap();
         assert_eq!(config.root_path(), &test_root);
 
         clean_up(&test_root);
@@ -140,7 +140,7 @@ mod test {
     #[test]
     fn returns_the_current_shell_name() {
         let test_root = set_up("current-shell-name", "current");
-        let config = FilesystemConfig::new(test_root.clone()).unwrap();
+        let config = FsConfig::new(test_root.clone()).unwrap();
         assert_eq!(config.current_shell_name(), "current".to_string());
 
         clean_up(&test_root);
@@ -149,7 +149,7 @@ mod test {
     #[test]
     fn can_set_the_current_shell_name() {
         let test_root = set_up("set-current-shell-name", "default");
-        let mut config = FilesystemConfig::new(test_root.clone()).unwrap();
+        let mut config = FsConfig::new(test_root.clone()).unwrap();
         config.set_current_shell_name("current");
         assert_eq!(config.current_shell_name(), "current".to_string());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::error::Error;
+use std::io::prelude::*;
 use std::path::PathBuf;
 
 pub trait Config {
@@ -5,9 +8,62 @@ pub trait Config {
 
     fn current_shell_name(&self) -> String;
 
-    fn set_current_shell_name(&mut self, name: &str);
+    fn set_current_shell_name(&mut self, name: &str); // TODO: Consider making this trait return `Result<(), Error>`.
 
     fn does_shell_exist(&self, name: &str) -> bool;
+}
+
+pub struct FilesystemConfig {
+    pub root_path: PathBuf,
+    pub current_shell: String,
+}
+
+impl FilesystemConfig {
+    // TODO: Make sure this actually works.
+    fn new(root_path: PathBuf) -> Self {
+        let config_path = root_path.join("current_shell");
+        let config_display = config_path.display();
+
+        let mut file = match File::open(&config_path) {
+            Ok(file) => file,
+            Err(e) => panic!("couldn't open {}: {}", config_display, e),
+        };
+
+        let mut current_shell = String::new();
+        match file.read_to_string(&mut current_shell) {
+            Ok(_) => {},
+            Err(e) => panic!("error: couldn't read {}: {}", config_display, e),
+        }
+
+        FilesystemConfig {
+            root_path: root_path,
+            current_shell: current_shell,
+        }
+    }
+
+}
+
+impl Config for FilesystemConfig {
+    fn root_path(&self) -> &PathBuf {
+        &self.root_path
+    }
+
+    // TODO: Does this actually need to read from the filesystem as well?
+    fn current_shell_name(&self) -> String {
+        self.current_shell.clone()
+    }
+
+    fn set_current_shell_name(&mut self, name: &str) {
+        // TODO: Write value of self.current_shell to `name` and
+        // update self.current_shell. This _might_ fail...
+        ()
+    }
+
+    fn does_shell_exist(&self, name: &str) -> bool {
+        // TODO: Check to see if a dir by `name` exists in
+        // self.root_path/shells. return true if exists, false otherwise.
+        true
+    }
 }
 
 #[cfg(test)]
@@ -40,4 +96,45 @@ pub mod mock {
             self.allowed_shell_names.contains(&name.to_string())
         }
     }
+}
+
+#[cfg(test)]
+mod test {
+    use super::FilesystemConfig;
+
+    // TODO: Figure out the best way to do FS setup/teardown in Rust.
+    /*
+    fn setup_test_dir() {
+    }
+
+    fn teardown_test_dir() {
+    }
+    */
+
+    // TODO: Make sure this actually works.
+    #[test]
+    fn has_a_root_path() {
+        let root_path = "./fs-config-test";
+        let config = FilesystemConfig::new(PathBuf::from(root_path));
+        assert_eq!(config.root_path(), "./fs-config-test")
+    }
+
+    // TODO: Actually implement the rest of the test methods.
+    /*
+    #[test]
+    fn returns_the_current_shell_name() {
+    }
+
+    #[test]
+    fn can_set_the_current_shell_name() {
+    }
+
+    #[test]
+    fn can_confirm_a_shell_exists() {
+    }
+
+    #[test]
+    fn can_confirm_a_shell_does_not_exist() {
+    }
+    */
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ pub trait Config {
 
     fn current_shell_name(&self) -> String;
 
-    fn set_current_shell_name(&mut self, name: &str) -> Result<(), io::Error>;
+    fn set_current_shell_name(&mut self, name: &str) -> io::Result<()>;
 
     fn does_shell_exist(&self, name: &str) -> bool;
 }
@@ -20,7 +20,7 @@ pub struct FsConfig {
 }
 
 impl FsConfig {
-    fn new(root_path: PathBuf) -> Result<Self, io::Error> {
+    fn new(root_path: PathBuf) -> io::Result<Self> {
         let config_path = root_path.join("current_shell");
         let config_display = config_path.display();
 
@@ -46,7 +46,7 @@ impl Config for FsConfig {
         self.current_shell.clone()
     }
 
-    fn set_current_shell_name(&mut self, name: &str) -> Result<(), io::Error> {
+    fn set_current_shell_name(&mut self, name: &str) -> io::Result<()> {
         let config_path = self.root_path.join("current_shell");
         let config_display = config_path.display();
 
@@ -88,7 +88,7 @@ pub mod mock {
             self.current_shell.clone()
         }
 
-        fn set_current_shell_name(&mut self, name: &str) -> Result<(), io::Error> {
+        fn set_current_shell_name(&mut self, name: &str) -> io::Result<()> {
             self.current_shell = name.to_string();
             Ok(())
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,6 @@ impl Config for FsConfig {
         &self.root_path
     }
 
-    // TODO: Does this actually need to read from the filesystem as well?
     fn current_shell_name(&self) -> String {
         self.current_shell.clone()
     }
@@ -60,16 +59,8 @@ impl Config for FsConfig {
     }
 
     fn does_shell_exist(&self, name: &str) -> io::Result<bool> {
-        // TODO: Check to see if a dir by `name` exists in
-        // self.root_path/shells. return true if exists, false otherwise.
-        let shell_root = self.root_path.join("shells");
-        Ok(try!(fs::read_dir(shell_root)).any(|entry| {
-            let entry = try!(entry);
-            entry.path().is_dir() && match entry.file_name().to_str() {
-                Some(n) => n == name,
-                None => false
-            }
-        }))
+        let shell_path = self.root_path.join("shells").join(name);
+        Ok(shell_path.is_dir())
     }
 }
 
@@ -185,11 +176,19 @@ mod test {
         clean_up(&test_root);
     }
 
-    // TODO: Actually implement the rest of the test methods.
-    //
-    // #[test]
-    // fn can_confirm_a_shell_does_not_exist() {
-    // }
-    //
+    #[test]
+    fn can_confirm_a_shell_does_not_exist() {
+        let test_root = set_up("confirm-shell-non-existence",
+                               "default",
+                               vec!["default", "other"]);
+        let mut config = FsConfig::new(test_root.clone()).unwrap();
+
+        let shell_exists = config.does_shell_exist("another");
+        assert!(shell_exists.is_ok());
+        assert!(!shell_exists.unwrap());
+
+        clean_up(&test_root);
+    }
+
 
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,9 +52,10 @@ impl Config for FsConfig {
 
         let mut file = try!(File::create(&config_path));
 
-        try!(file.write_all(self.current_shell.as_bytes()));
+        try!(file.write_all(name.as_bytes()));
 
         self.current_shell = name.to_string();
+
         Ok(())
     }
 
@@ -157,7 +158,14 @@ mod test {
         let test_root = set_up("set-current-shell-name", "default", vec!["default"]);
         let mut config = FsConfig::new(test_root.clone()).unwrap();
         config.set_current_shell_name("current");
-        assert_eq!(config.current_shell_name(), "current".to_string());
+
+        let mut config_file = File::open(&test_root.join("current_shell")).unwrap();
+        let mut name_on_disk = String::new();
+        config_file.read_to_string(&mut name_on_disk).unwrap();
+
+        let current = "current".to_string();
+        assert_eq!(config.current_shell_name(), current);
+        assert_eq!(name_on_disk, current);
 
         clean_up(&test_root);
     }

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -25,7 +25,7 @@ impl<T: Config> Hermit<T> {
     }
 
     fn set_current_shell(&mut self, name: &str) -> Result<(), Error> {
-        if try!(self.config.does_shell_exist(name)) {
+        if self.config.does_shell_exist(name) {
             self.config.set_current_shell_name(name).map_err(From::from)
         } else {
             Err(Error::ShellDoesNotExist)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 #[macro_use]
 extern crate clap;
 


### PR DESCRIPTION
Implements the `Config` trait with `FsConfig`, an object backed by persistent storage of the configuration for `hermit` in a file called `$HERMIT_ROOT/current_shell`.