### PR TITLE
Refactor config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -91,7 +91,7 @@ pub mod mock {
 
     use super::Config;
 
-    #[derive(Clone)]
+    #[derive(Clone,Debug,Eq,PartialEq)]
     pub struct MockConfig {
         pub root_path: PathBuf,
         pub current_shell: String,

--- a/src/env.rs
+++ b/src/env.rs
@@ -28,9 +28,7 @@ mod tests {
     use super::*;
 
     use std::env;
-    use std::thread;
     use std::sync::Mutex;
-    use std::time::Duration;
     use std::path::PathBuf;
 
     lazy_static! {

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -49,7 +49,8 @@ impl<T: Config> Hermit<T> {
     }
 
     pub fn init_shell(&self, file_ops: &mut FileOperations, name: &str) {
-        let path = self.config.shell_root_path().join(name);
+        let new_shell = Shell::new(name, self.config.clone());
+        let path = new_shell.root_path();
         file_ops.create_git_repo(path);
     }
 }

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -28,10 +28,10 @@ impl<T: Config> Hermit<T> {
         Hermit { config: Rc::new(config) }
     }
 
-    pub fn current_shell(&self) -> Option<Shell> {
+    pub fn current_shell(&self) -> Option<Shell<T>> {
         self.config
             .current_shell_name()
-            .map(|shell_name| Shell::new(shell_name, self.config.root_path()))
+            .map(|shell_name| Shell::new(shell_name, self.config.clone()))
     }
 
     pub fn set_current_shell(&mut self, name: &str) -> Result<(), Error> {
@@ -57,8 +57,8 @@ impl<T: Config> Hermit<T> {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::rc::Rc;
 
-    use config::Config;
     use config::mock::MockConfig;
     use file_operations::FileOperations;
     use file_operations::Op;
@@ -84,7 +84,7 @@ mod tests {
 
         let shell = hermit.current_shell().unwrap();
         assert_eq!(shell.name, "default");
-        assert_eq!(shell.root_path, config.root_path());
+        assert_eq!(shell.config, Rc::new(config));
     }
 
     #[test]


### PR DESCRIPTION
This reduces the duplication of knowledge of where shell root directories are stored relative to the `hermit_root` from 3 places(!) to only one.

Additionally, this has the added bonus that if the config needs to be mutated by an action, that code path can't also instantiate a `Shell` which could potentially read from the config object.