### PR TITLE
Rework subcommand macro syntax

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,14 +1,14 @@
 macro_rules! subcommand {
-    (
-        $name:ident, $fn_name:ident {
+    {
+        $fn_name:ident ( $name:expr ) {
             $(
-                $method:ident($($args:expr),*)
-            );*
+                $method:ident ( $($args:expr),* )
+            )*
         }
-    ) => {
+    } => {
         fn $fn_name<'a, 'b, 'c, 'd, 'e, 'f>(app: App<'a, 'b, 'c, 'd, 'e, 'f>)
                                                    -> App<'a, 'b, 'c, 'd, 'e, 'f> {
-            let subcommand = SubCommand::with_name(stringify!($name))
+            let subcommand = SubCommand::with_name($name)
                 $(
                     .$method($($args),*)
                 )*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,9 +92,11 @@ fn make_app_config<'a, 'b, 'c, 'd, 'e, 'f>() -> App<'a, 'b, 'c, 'd, 'e, 'f> {
 // Subcommand configuration and implementation
 // **************************************************
 
-subcommand!(add, add_add_subcommand {
-   about("Add files to your hermit shell")
-});
+subcommand!{
+  add_add_subcommand("add") {
+    about("Add files to your hermit shell")
+  }
+}
 
 fn handle_add<C: Config>(_matches: &ArgMatches,
                          _hermit: &mut Hermit<C>,
@@ -103,9 +105,11 @@ fn handle_add<C: Config>(_matches: &ArgMatches,
 }
 
 
-subcommand!(clone, add_clone_subcommand {
+subcommand!{
+  add_clone_subcommand("clone") {
     about("Create a local shell from an existing remote shell")
-});
+  }
+}
 
 fn handle_clone<C: Config>(_matches: &ArgMatches,
                            _hermit: &mut Hermit<C>,
@@ -114,9 +118,11 @@ fn handle_clone<C: Config>(_matches: &ArgMatches,
 }
 
 
-subcommand!(doctor, add_doctor_subcommand {
+subcommand!{
+  add_doctor_subcommand("doctor") {
     about("Make sure your hermit setup is sane")
-});
+  }
+}
 
 fn handle_doctor<C: Config>(_matches: &ArgMatches,
                             _hermit: &mut Hermit<C>,
@@ -125,9 +131,12 @@ fn handle_doctor<C: Config>(_matches: &ArgMatches,
 }
 
 
-subcommand!(git, add_git_subcommand {
+
+subcommand!{
+  add_git_subcommand("git") {
     about("Run git operations on the current shell")
-});
+  }
+}
 
 fn handle_git<C: Config>(_matches: &ArgMatches,
                          _hermit: &mut Hermit<C>,
@@ -136,11 +145,13 @@ fn handle_git<C: Config>(_matches: &ArgMatches,
 }
 
 
-subcommand!(init, add_init_subcommand {
+subcommand!{
+  add_init_subcommand("init") {
     about("Create a new hermit shell called SHELL_NAME. If no shell name \
-           is given, \"default\" is used.");
+           is given, \"default\" is used.")
     arg(Arg::with_name("SHELL_NAME").help("The name of the shell to be created."))
-});
+  }
+}
 
 fn handle_init<C: Config>(matches: &ArgMatches,
                           hermit: &mut Hermit<C>,
@@ -150,9 +161,11 @@ fn handle_init<C: Config>(matches: &ArgMatches,
 }
 
 
-subcommand!(nuke, add_nuke_subcommand {
+subcommand!{
+  add_nuke_subcommand("nuke") {
     about("Permanently remove a hermit shell")
-});
+  }
+}
 
 fn handle_nuke<C: Config>(_matches: &ArgMatches,
                           _hermit: &mut Hermit<C>,
@@ -161,9 +174,11 @@ fn handle_nuke<C: Config>(_matches: &ArgMatches,
 }
 
 
-subcommand!(status, add_status_subcommand {
+subcommand!{
+  add_status_subcommand("status") {
     about("Display the status of your hermit shell")
-});
+  }
+}
 
 fn handle_status<C: Config>(_matches: &ArgMatches,
                             _hermit: &mut Hermit<C>,
@@ -172,9 +187,11 @@ fn handle_status<C: Config>(_matches: &ArgMatches,
 }
 
 
-subcommand!(use, add_use_subcommand {
+subcommand!{
+  add_use_subcommand("use") {
     about("Switch to using a different hermit shell")
-});
+  }
+}
 
 fn handle_use<C: Config>(_matches: &ArgMatches,
                          _hermit: &mut Hermit<C>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn report_errors(results: Vec<file_operations::Result>) {
 fn make_app_config<'a, 'b, 'c, 'd, 'e, 'f>() -> App<'a, 'b, 'c, 'd, 'e, 'f> {
     let app = App::new("hermit")
         .version(env!("CARGO_PKG_VERSION"))
-        .author("Bike Barn <https://github.com/bike-barn/hermit>")
+        .author("A product of the Bike Barn <https://github.com/bike-barn/hermit>")
         .about("A home directory configuration management assistant.")
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .setting(AppSettings::VersionlessSubcommands);

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,10 +66,8 @@ fn report_errors(results: Vec<file_operations::Result>) {
 }
 
 fn make_app_config<'a, 'b, 'c, 'd, 'e, 'f>() -> App<'a, 'b, 'c, 'd, 'e, 'f> {
-    let version = env!("CARGO_PKG_VERSION");
-
     let app = App::new("hermit")
-        .version(version)
+        .version(env!("CARGO_PKG_VERSION"))
         .author("Bike Barn <https://github.com/bike-barn/hermit>")
         .about("A home directory configuration management assistant.")
         .setting(AppSettings::SubcommandRequiredElseHelp)


### PR DESCRIPTION
Mostly playing around with what you can do with rust macros.  It's unfortunate that they need to have one matched delimiter pair surrounding the whole macro body. If that wasn't true I have a much nicer syntax in mind, but this is arguably better I think.
