### PR TITLE
Improve CI tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
 cache: cargo
 
 before_script:
+  - cargo +nightly clippy --version || ( rustup install nightly && cargo +nightly install clippy )
   - cargo tarpaulin --version || RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
   - curl -o /tmp/urchin https://raw.githubusercontent.com/tlevine/urchin/v0.0.6/urchin && chmod +x /tmp/urchin
   - git fetch --unshallow
@@ -20,6 +21,7 @@ before_script:
   - git checkout master
   - git checkout -
 script:
+  - cargo +nightly clippy
   - ./runtests.sh
 
 after_success: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
 cache: cargo
 
 before_script:
+  - cargo tarpaulin --version || RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
   - curl -o /tmp/urchin https://raw.githubusercontent.com/tlevine/urchin/v0.0.6/urchin && chmod +x /tmp/urchin
   - git fetch --unshallow
   - git config remote.$(git remote | head -n1).fetch "+refs/heads/*:refs/remotes/$(git remote | head -n1)/*"
@@ -23,8 +24,6 @@ script:
 
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    `RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin`
-    # Uncomment the following line for coveralls.io
     cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: rust
 rust:
   - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ rust:
   - stable
   - beta
   - nightly
+
 matrix:
   allow_failures:
     - rust: nightly
+
 cache: cargo
 
 before_script:
@@ -19,6 +21,13 @@ before_script:
 script:
   - ./runtests.sh
 
+after_success: |
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+    `RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin`
+    # Uncomment the following line for coveralls.io
+    cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
+  fi
+
 addons:
   apt:
     sources:
@@ -28,6 +37,7 @@ addons:
       - libcurl4-openssl-dev
       - libelf-dev
       - libdw-dev
+      - libssl-dev
 
 notifications:
   slack:

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ number of tests, but there may (will!) be bugs._
 
 [![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
 [![Build Status][badge-build]](https://travis-ci.org/bike-barn/hermit)
+[![Coverage Status][badge-coverage]](https://coveralls.io/github/bike-barn/hermit)
 [![Stories Ready to Work On][badge-todo]](https://waffle.io/bike-barn/hermit)
 [![Crabs harmed][badge-crabs]](http://shields.io/)
 
 [badge-license]: https://img.shields.io/badge/license-GPL_3-green.svg
 [badge-build]: https://travis-ci.org/bike-barn/hermit.svg?branch=master
+[badge-coverage]: https://coveralls.io/repos/github/bike-barn/hermit/badge.svg
 [badge-todo]: https://badge.waffle.io/bike-barn/hermit.svg?label=to-do&title=To-Do
 [badge-crabs]: http://img.shields.io/badge/crabs_harmed-0-blue.svg
 


### PR DESCRIPTION
This adds both code coverage (via [tarpaulin](https://github.com/xd009642/tarpaulin) and [Coveralls](https://coveralls.io/github/bike-barn/hermit)), and code linting (via [clippy](https://github.com/rust-lang-nursery/rust-clippy)).

Failing the build based on lint warnings is not enabled yet, since there are a bunch of warnings currently.  But as soon as we have merged commits dealing with all the warnings that should be enabled too.