### PR TITLE
Implement inhabit v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -281,6 +282,14 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "same-file"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +397,15 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
+"checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -465,6 +484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,7 +1,10 @@
 [[package]]
 name = "ansi_term"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "atty"
@@ -10,13 +13,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -29,15 +27,20 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cfg-if"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "clap"
-version = "2.29.0"
+version = "2.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -61,7 +64,7 @@ dependencies = [
  "openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -99,12 +102,13 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.6.11"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -114,10 +118,10 @@ dependencies = [
 name = "hermit"
 version = "0.0.1"
 dependencies = [
- "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -142,7 +146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.6.19"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -175,6 +179,14 @@ dependencies = [
  "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -220,11 +232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.20"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -242,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -257,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -307,10 +320,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.5.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -330,11 +344,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -344,21 +358,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
-"checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
+"checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
+"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "dfcf5bcece56ef953b8ea042509e9dcbdfe97820b7e20d86beb53df30ed94978"
 "checksum curl-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46e49c7125131f5afaded06944d6888b55cbdf8eba05dae73c954019b907961"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
@@ -366,36 +380,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "91ecd03771effb0c968fd6950b37e89476a578aaf1c70297d8e92b6516ec3312"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
-"checksum git2 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ee5b4bb7cd2a44e6e5ee3a26ba6a9ca10d4ce2771cdc3839bbc54b47b7d1be84"
+"checksum git2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "910a2df52d2354e4eb27aa12f3803ea86bf461a93e17028908ec0e356572aa7b"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"
-"checksum libgit2-sys 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6eeae66e7b1c995de45cb4e65c5ab438a96a7b4077e448645d4048dc753ad357"
+"checksum libgit2-sys 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7adce4cc6db027611f537837a7c404319b6314dae49c5db80ad5332229894751"
 "checksum libssh2-sys 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0db4ec23611747ef772db1c4d650f8bd762f07b461727ec998f953c614024b75"
 "checksum libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "40f2df7730b5d29426c3e44ce4d088d8c5def6471c2c93ba98585b89fb201ce6"
+"checksum log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "61bd98ae7f7b754bc53dca7d44b604f733c6bba044ea6f41bc8d89272d8161d2"
 "checksum matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "15305656809ce5a4805b1ff2946892810992197ce1270ff79baded852187942e"
 "checksum metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b1482f9a06f56c906007e17ea14d73d102210b5d27bc948bf5e175f493f3f7c3"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
-"checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
+"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
-"checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
+"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b09fb3b6f248ea4cd42c9a65113a847d612e17505d6ebd1f7357ad68a8bf8693"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
-"checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,20 +113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "gcc"
 version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,7 +149,6 @@ dependencies = [
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -276,16 +261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rand"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -403,15 +378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "vcpkg"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,8 +430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "91ecd03771effb0c968fd6950b37e89476a578aaf1c70297d8e92b6516ec3312"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum git2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "910a2df52d2354e4eb27aa12f3803ea86bf461a93e17028908ec0e356572aa7b"
@@ -483,7 +447,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
@@ -500,7 +463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
-"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +94,25 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "failure"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +159,8 @@ name = "hermit"
 version = "0.0.1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -231,6 +273,11 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rand"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,9 +301,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "termion"
@@ -297,6 +376,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-width"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -369,6 +453,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
+"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+"checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
@@ -376,6 +462,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "dfcf5bcece56ef953b8ea042509e9dcbdfe97820b7e20d86beb53df30ed94978"
 "checksum curl-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46e49c7125131f5afaded06944d6888b55cbdf8eba05dae73c954019b907961"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
+"checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "91ecd03771effb0c968fd6950b37e89476a578aaf1c70297d8e92b6516ec3312"
@@ -394,16 +482,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b1482f9a06f56c906007e17ea14d73d102210b5d27bc948bf5e175f493f3f7c3"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["home", "directory", "configuration", "management", "dotfiles"]
 license = "GPL-3.0"
 
 [dependencies]
-clap = "2.32"
-failure = "0.1"
-failure_derive = "0.1"
-git2 = "0.7"
+clap = "~2.32.0"
+failure = "~0.1.1"
+failure_derive = "~0.1.1"
+git2 = "~0.7.2"
 
 [dev-dependencies]
-lazy_static = "1.0"
+lazy_static = "~1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ keywords = ["home", "directory", "configuration", "management", "dotfiles"]
 license = "GPL-3.0"
 
 [dependencies]
-clap = "2.29.0"
-git2 = "0.6"
-uuid = {version = "0.5.1", features = ["v4"]}
+clap = "2.32"
+git2 = "0.7"
+uuid = { version = "0.6", features = ["v4"] }
 
 [dev-dependencies]
-lazy_static = "1.0.0"
+lazy_static = "1.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap = "~2.32.0"
 failure = "~0.1.1"
 failure_derive = "~0.1.1"
 git2 = "~0.7.2"
+walkdir = "~2.1.4"
 
 [dev-dependencies]
 lazy_static = "~1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ license = "GPL-3.0"
 
 [dependencies]
 clap = "2.32"
+failure = "0.1"
+failure_derive = "0.1"
 git2 = "0.7"
 uuid = { version = "0.6", features = ["v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ clap = "2.32"
 failure = "0.1"
 failure_derive = "0.1"
 git2 = "0.7"
-uuid = { version = "0.6", features = ["v4"] }
 
 [dev-dependencies]
 lazy_static = "1.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  build:
+    build: image/
+    volumes:
+      - ./:/work

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:stable
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    ca-certificates \
+    curl \
+    git \
+    pkg-config \
+    libssl-dev \
+    zlib1g-dev
+
+ARG RUST_VERSION=stable
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${RUST_VERSION} -y
+
+ENV PATH=/root/.cargo/bin:$PATH
+
+RUN cargo install just
+
+VOLUME /work
+
+WORKDIR /work

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,6 +202,10 @@ pub mod mock {
                 files: vec![],
             }
         }
+
+        pub fn set_paths(&mut self, paths: Vec<impl AsRef<Path>>) {
+            self.files = paths.into_iter().map(|p| PathBuf::from(p.as_ref())).collect();
+        }
     }
 
     impl Config for MockConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,9 @@ use std::path::{Path, PathBuf};
 pub trait Config {
     fn root_path(&self) -> &PathBuf;
 
-    fn shell_root_path(&self) -> PathBuf;
+    fn shell_root_path(&self) -> PathBuf {
+        self.root_path().join("shells")
+    }
 
     fn current_shell_name(&self) -> Option<String>;
 
@@ -56,10 +58,6 @@ impl FsConfig {
 impl Config for FsConfig {
     fn root_path(&self) -> &PathBuf {
         &self.root_path
-    }
-
-    fn shell_root_path(&self) -> PathBuf {
-        self.root_path.join("shells")
     }
 
     fn current_shell_name(&self) -> Option<String> {
@@ -117,10 +115,6 @@ pub mod mock {
     impl Config for MockConfig {
         fn root_path(&self) -> &PathBuf {
             &self.root_path
-        }
-
-        fn shell_root_path(&self) -> PathBuf {
-            self.root_path.join("shells")
         }
 
         fn current_shell_name(&self) -> Option<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -359,6 +359,8 @@ mod test {
             .into_iter()
             .map(|f| f.to_string_lossy().to_string())
             .collect::<Vec<_>>();
-        assert_eq!(files, vec!["file1", "subdir/file2"]);
+        assert!(files.contains(&"file1".into()));
+        assert!(files.contains(&"subdir/file2".into()));
+        assert!(! files.contains(&"subdir".into()));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub trait Config {
 
     fn set_current_shell_name(&mut self, name: &str) -> io::Result<()>;
 
-    fn does_shell_exist(&self, name: &str) -> bool;
+    fn shell_exists(&self, name: &str) -> bool;
 }
 
 #[derive(Clone)]
@@ -78,7 +78,7 @@ impl Config for FsConfig {
         Ok(())
     }
 
-    fn does_shell_exist(&self, name: &str) -> bool {
+    fn shell_exists(&self, name: &str) -> bool {
         let shell_path = self.root_path.join("shells").join(name);
         shell_path.is_dir()
     }
@@ -138,7 +138,7 @@ pub mod mock {
             Ok(())
         }
 
-        fn does_shell_exist(&self, name: &str) -> bool {
+        fn shell_exists(&self, name: &str) -> bool {
             self.allowed_shell_names.contains(&name.to_owned())
         }
     }
@@ -224,7 +224,7 @@ mod test {
                                vec!["default", "other"]);
         let config = FsConfig::new(test_root.clone());
 
-        assert!(config.does_shell_exist("other"));
+        assert!(config.shell_exists("other"));
 
         clean_up(&test_root);
     }
@@ -236,10 +236,8 @@ mod test {
                                vec!["default", "other"]);
         let config = FsConfig::new(test_root.clone());
 
-        assert!(!config.does_shell_exist("another"));
+        assert!(!config.shell_exists("another"));
 
         clean_up(&test_root);
     }
-
-
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,8 +19,8 @@ pub trait Config {
 
 #[derive(Clone)]
 pub struct FsConfig {
-    pub root_path: PathBuf,
-    pub current_shell: Option<String>,
+    root_path: PathBuf,
+    current_shell: Option<String>,
 }
 
 impl FsConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,9 +33,7 @@ impl FsConfig {
     }
 
     fn read_current_shell(&self) -> io::Result<String> {
-        let config_path = self.root_path.join("current_shell");
-
-        let mut file = File::open(&config_path)?;
+        let mut file = File::open(&self.config_path())?;
         let mut current_shell = String::new();
 
         file.read_to_string(&mut current_shell)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,15 +87,33 @@ impl Config for FsConfig {
 #[cfg(test)]
 pub mod mock {
     use std::io;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use super::Config;
 
     #[derive(Clone,Debug,Eq,PartialEq)]
     pub struct MockConfig {
-        pub root_path: PathBuf,
-        pub current_shell: String,
-        pub allowed_shell_names: Vec<String>,
+        root_path: PathBuf,
+        current_shell: String,
+        allowed_shell_names: Vec<String>,
+    }
+
+    impl MockConfig {
+        pub fn new() -> MockConfig {
+            MockConfig {
+                root_path: PathBuf::from("/"),
+                allowed_shell_names: vec!["default".to_owned()],
+                current_shell: "default".to_owned(),
+            }
+        }
+
+        pub fn with_root(root: impl AsRef<Path>) -> MockConfig {
+            MockConfig {
+                root_path: PathBuf::from(root.as_ref()),
+                allowed_shell_names: vec!["default".to_owned()],
+                current_shell: "default".to_owned(),
+            }
+        }
     }
 
     impl Config for MockConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct FsConfig {
 }
 
 impl FsConfig {
-    pub fn new<P: AsRef<Path>>(root_path: P) -> Self {
+    pub fn new(root_path: impl AsRef<Path>) -> Self {
         let root_path = PathBuf::from(root_path.as_ref());
         FsConfig {
             root_path: root_path,

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,11 @@ pub trait Config {
 
     fn current_shell_name(&self) -> Option<&str>;
 
+    fn current_shell_path(&self) -> Option<PathBuf> {
+        self.current_shell_name()
+            .map(|name| self.shell_root_path().join(name))
+    }
+
     fn set_current_shell_name(&mut self, name: &str) -> io::Result<()>;
 
     fn shell_exists(&self, name: &str) -> bool;
@@ -73,7 +78,7 @@ impl Config for FsConfig {
     }
 
     fn shell_exists(&self, name: &str) -> bool {
-        let shell_path = self.root_path.join("shells").join(name);
+        let shell_path = self.shell_root_path().join(name);
         shell_path.is_dir()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,8 +185,6 @@ mod test {
         let test_root = set_up("root-path", "default", vec!["default"]);
         let config = FsConfig::new(test_root.clone());
         assert_eq!(config.root_path(), &test_root);
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -196,8 +194,6 @@ mod test {
         config.initialize().expect("Reading shell_name config file");
 
         assert_eq!(config.current_shell_name().unwrap(), "current".to_string());
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -213,8 +209,6 @@ mod test {
         let current = "current".to_string();
         assert_eq!(config.current_shell_name().unwrap(), current);
         assert_eq!(name_on_disk, current);
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -225,8 +219,6 @@ mod test {
         let config = FsConfig::new(test_root.clone());
 
         assert!(config.shell_exists("other"));
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -237,7 +229,5 @@ mod test {
         let config = FsConfig::new(test_root.clone());
 
         assert!(!config.shell_exists("another"));
-
-        clean_up(&test_root);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,10 +35,10 @@ impl FsConfig {
     fn read_current_shell(&self) -> io::Result<String> {
         let config_path = self.root_path.join("current_shell");
 
-        let mut file = try!(File::open(&config_path));
+        let mut file = File::open(&config_path)?;
         let mut current_shell = String::new();
 
-        try!(file.read_to_string(&mut current_shell));
+        file.read_to_string(&mut current_shell)?;
 
         Ok(current_shell)
     }
@@ -50,7 +50,7 @@ impl FsConfig {
 
 impl Config for FsConfig {
     fn initialize(&mut self) -> io::Result<()> {
-        let current_shell = try!(self.read_current_shell());
+        let current_shell = self.read_current_shell()?;
         self.current_shell = Some(current_shell);
 
         Ok(())
@@ -69,9 +69,9 @@ impl Config for FsConfig {
     }
 
     fn set_current_shell_name(&mut self, name: &str) -> io::Result<()> {
-        let mut file = try!(File::create(&self.config_path()));
+        let mut file = File::create(&self.config_path())?;
 
-        try!(file.write_all(name.as_bytes()));
+        file.write_all(name.as_bytes())?;
 
         self.current_shell = Some(name.to_string());
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -9,7 +9,7 @@ pub fn get_program_name() -> String {
         .map(PathBuf::from)
         .and_then(|path| path.file_name().map(|name| name.to_owned()))
         .and_then(|file_name| file_name.to_str().map(|name| name.to_owned()))
-        .unwrap_or("hermit".to_owned())
+        .unwrap_or_else(|| "hermit".to_owned())
 }
 
 pub fn get_hermit_dir() -> Option<PathBuf> {

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -138,8 +138,6 @@ mod tests {
             Ok(val) => assert!(val.file_type().is_symlink()),
             Err(_err) => panic!("{:?} does not exist", link_path),
         };
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -155,8 +153,6 @@ mod tests {
         assert_eq!(results.len(), 1);
         results[0].as_ref().expect("Op failed");
         assert!(!test_root.join("file_a").exists());
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -171,8 +167,6 @@ mod tests {
         assert_eq!(results.len(), 1);
         results[0].as_ref().expect("Op failed");
         assert!(test_root.join("test").is_dir());
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -188,8 +182,6 @@ mod tests {
         assert_eq!(results.len(), 1);
         results[0].as_ref().expect_err("Op unexpectedly succeeded");
         assert!(!test_root.join("test").is_dir());
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -205,8 +197,6 @@ mod tests {
         assert_eq!(results.len(), 1);
         results[0].as_ref().expect("Op failed");
         assert!(test_root.join("test").is_dir());
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -221,8 +211,6 @@ mod tests {
         assert_eq!(results.len(), 1);
         results[0].as_ref().expect("Op failed");
         assert!(test_root.join(".git").is_dir());
-
-        clean_up(&test_root);
     }
 
     #[test]
@@ -238,8 +226,6 @@ mod tests {
         assert_eq!(results.len(), 1);
         results[0].as_ref().expect("Op failed");
         assert!(test_root.join(&path).join(".git").is_dir());
-
-        clean_up(&test_root);
     }
 
     #[test]

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -37,8 +37,8 @@ impl From<git2::Error> for Error {
 pub type Result = result::Result<(), Error>;
 
 pub struct FileOperations {
-    pub root: PathBuf,
-    pub operations: Vec<Op>,
+    root: PathBuf,
+    operations: Vec<Op>,
     git_init_opts: git2::RepositoryInitOptions,
 }
 
@@ -56,6 +56,10 @@ impl FileOperations {
         opts.no_reinit(true);
 
         opts
+    }
+
+    pub fn operations(&self) -> &Vec<Op> {
+        &self.operations
     }
 
     pub fn create_dir<P: AsRef<Path>>(&mut self, name: P) {

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -1,4 +1,4 @@
-use std::{fs, io, result};
+use std::{fs, io, mem, result};
 use std::os::unix;
 use std::path::{Path, PathBuf};
 
@@ -83,12 +83,9 @@ impl FileOperations {
     }
 
     pub fn commit(mut self) -> Vec<Result> {
-        let ops = self.operations;
-        self.operations = vec![];
-
-        ops.into_iter()
-           .map(|op| self.do_op(op))
-           .collect::<Vec<_>>()
+        mem::replace(&mut self.operations, vec![]).into_iter()
+            .map(|op| self.do_op(op))
+            .collect::<Vec<_>>()
     }
 
     /// Private Methods

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -132,8 +132,7 @@ mod tests {
         let results = file_set.commit();
 
         assert_eq!(results.len(), 1);
-        println!("{:?}", results[0]);
-        assert!(results[0].is_ok());
+        results[0].as_ref().expect("Op failed");
 
         match fs::symlink_metadata(&link_path) {
             Ok(val) => assert!(val.file_type().is_symlink()),
@@ -154,7 +153,7 @@ mod tests {
         let results = file_set.commit();
 
         assert_eq!(results.len(), 1);
-        assert!(results[0].is_ok());
+        results[0].as_ref().expect("Op failed");
         assert!(!test_root.join("file_a").exists());
 
         clean_up(&test_root);
@@ -170,7 +169,7 @@ mod tests {
         assert!(!test_root.join("test").is_dir());
         let results = file_set.commit();
         assert_eq!(results.len(), 1);
-        assert!(results[0].is_ok());
+        results[0].as_ref().expect("Op failed");
         assert!(test_root.join("test").is_dir());
 
         clean_up(&test_root);
@@ -187,7 +186,7 @@ mod tests {
         assert!(!test_root.join("test").is_dir());
         let results = file_set.commit();
         assert_eq!(results.len(), 1);
-        assert!(results[0].is_err());
+        results[0].as_ref().expect_err("Op unexpectedly succeeded");
         assert!(!test_root.join("test").is_dir());
 
         clean_up(&test_root);
@@ -204,7 +203,7 @@ mod tests {
         assert!(!test_root.join("test").is_dir());
         let results = file_set.commit();
         assert_eq!(results.len(), 1);
-        assert!(results[0].is_ok());
+        results[0].as_ref().expect("Op failed");
         assert!(test_root.join("test").is_dir());
 
         clean_up(&test_root);
@@ -220,7 +219,7 @@ mod tests {
         assert!(!test_root.join(".git").is_dir());
         let results = file_set.commit();
         assert_eq!(results.len(), 1);
-        assert!(results[0].is_ok());
+        results[0].as_ref().expect("Op failed");
         assert!(test_root.join(".git").is_dir());
 
         clean_up(&test_root);
@@ -237,7 +236,7 @@ mod tests {
         assert!(!test_root.join(&path).join(".git").is_dir());
         let results = file_set.commit();
         assert_eq!(results.len(), 1);
-        assert!(results[0].is_ok());
+        results[0].as_ref().expect("Op failed");
         assert!(test_root.join(&path).join(".git").is_dir());
 
         clean_up(&test_root);
@@ -253,7 +252,7 @@ mod tests {
 
         let results = file_set.commit();
         assert_eq!(results.len(), 2);
-        assert!(results[0].is_ok());
-        assert!(results[1].is_err());
+        results[0].as_ref().expect("Op failed");
+        results[1].as_ref().expect_err("Op unexpectedly succeeded");
     }
 }

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -43,7 +43,7 @@ pub struct FileOperations {
 }
 
 impl FileOperations {
-    pub fn rooted_at<P: AsRef<Path>>(path: P) -> FileOperations {
+    pub fn rooted_at(path: impl AsRef<Path>) -> FileOperations {
         FileOperations {
             root: PathBuf::from(path.as_ref()),
             operations: vec![],
@@ -62,11 +62,11 @@ impl FileOperations {
         &self.operations
     }
 
-    pub fn create_dir<P: AsRef<Path>>(&mut self, name: P) {
+    pub fn create_dir(&mut self, name: impl AsRef<Path>) {
         self.operations.push(Op::MkDir(self.root.join(name)))
     }
 
-    pub fn create_dir_all<P: AsRef<Path>>(&mut self, name: P) {
+    pub fn create_dir_all(&mut self, name: impl AsRef<Path>) {
         self.operations.push(Op::MkDirAll(self.root.join(name)))
     }
 
@@ -74,11 +74,11 @@ impl FileOperations {
         self.operations.push(Op::Link(source.as_ref().to_path_buf(), self.root.join(dest)));
     }
 
-    pub fn remove<P: AsRef<Path>>(&mut self, file: P) {
+    pub fn remove(&mut self, file: impl AsRef<Path>) {
         self.operations.push(Op::Remove(self.root.join(file)));
     }
 
-    pub fn create_git_repo<P: AsRef<Path>>(&mut self, name: P) {
+    pub fn create_git_repo(&mut self, name: impl AsRef<Path>) {
         self.operations.push(Op::GitInit(self.root.join(name)))
     }
 

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -1,11 +1,10 @@
-use std::{error, fmt, fs, io, result};
+use std::{fs, io, result};
 use std::os::unix;
 use std::path::{Path, PathBuf};
 
 use git2;
 
-#[derive(PartialEq,Eq)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Op {
     MkDir(PathBuf),
     MkDirAll(PathBuf),
@@ -14,35 +13,13 @@ pub enum Op {
     Remove(PathBuf),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum Error {
-    IoError(io::Error),
-    Git2Error(git2::Error),
-}
+    #[fail(display = "IO error: {}", _0)]
+    IoError(#[cause] io::Error),
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::IoError(ref err) => write!(f, "IO error: {}", err),
-            Error::Git2Error(ref err) => write!(f, "Git2 error: {}", err),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::IoError(ref err) => err.description(),
-            Error::Git2Error(ref err) => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            Error::IoError(ref err) => Some(err),
-            Error::Git2Error(ref err) => Some(err),
-        }
-    }
+    #[fail(display = "Git2 error: {}", _0)]
+    Git2Error(#[cause] git2::Error),
 }
 
 impl From<io::Error> for Error {

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -104,7 +104,6 @@ impl FileOperations {
     pub fn commit(mut self) -> Vec<Result> {
         let ops = self.operations;
         self.operations = vec![];
-        self.operations.push(Op::MkDir(PathBuf::new()));
 
         ops.into_iter()
            .map(|op| self.do_op(op))

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -94,16 +94,16 @@ impl FileOperations {
         match op {
             Op::MkDir(dir) => fs::create_dir(dir)?,
             Op::MkDirAll(dir) => fs::create_dir_all(dir)?,
-            Op::GitInit(dir) => self.git_init(dir)?,
+            Op::GitInit(dir) => git_init(dir, &self.git_init_opts)?,
             Op::Link(src, dest) => unix::fs::symlink(src, dest)?,
             Op::Remove(file) => fs::remove_file(file)?,
         };
         Ok(())
     }
+}
 
-    fn git_init(&self, dir: PathBuf) -> result::Result<(), git2::Error> {
-        git2::Repository::init_opts(dir, &self.git_init_opts).map(|_| ())
-    }
+fn git_init(dir: PathBuf, options: &git2::RepositoryInitOptions) -> result::Result<(), git2::Error> {
+    git2::Repository::init_opts(dir, options).map(|_| ())
 }
 
 #[cfg(test)]

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -35,7 +35,7 @@ impl<T: Config> Hermit<T> {
     }
 
     pub fn set_current_shell(&mut self, name: &str) -> Result<(), Error> {
-        if self.config.does_shell_exist(name) {
+        if self.config.shell_exists(name) {
             match Rc::get_mut(&mut self.config) {
                 Some(config) => config.set_current_shell_name(name).map_err(From::from),
                 None => {

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -39,8 +39,7 @@ impl<T: Config> Hermit<T> {
             match Rc::get_mut(&mut self.config) {
                 Some(config) => config.set_current_shell_name(name).map_err(From::from),
                 None => {
-                    unreachable!(message::error("attempted to modify config while it was being \
-                                                 used."))
+                    unreachable!(message::error_str("attempted to modify config while it was being used."))
                 }
             }
         } else {

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -6,8 +6,12 @@ use file_operations::FileOperations;
 use message;
 use shell::Shell;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Fail, PartialEq, Eq)]
 pub enum Error {
+    #[fail(display = "`hermit {}` is not implemented yet", _0)]
+    SubcommandNotImplemented(&'static str),
+
+    #[fail(display = "That is not the name of a shell")]
     ShellDoesNotExist,
 }
 

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -8,7 +8,7 @@ use shell::Shell;
 
 #[derive(Clone, Debug, Fail, PartialEq, Eq)]
 pub enum Error {
-    #[fail(display = "`hermit {}` is not implemented yet", _0)]
+    #[fail(display = "{} subcommand has not been implemented yet", _0)]
     SubcommandNotImplemented(&'static str),
 
     #[fail(display = "That is not the name of a shell")]

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -120,7 +120,7 @@ mod tests {
         let mut file_ops = FileOperations::rooted_at("/home/geoff");
 
         hermit.init_shell(&mut file_ops, "new-one");
-        let first_op = &file_ops.operations[0];
+        let first_op = &file_ops.operations()[0];
         assert_eq!(*first_op,
                    Op::GitInit(PathBuf::from("/home/geoff/.hermit-config/shells/new-one")));
     }

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -59,6 +59,7 @@ mod tests {
     use std::path::PathBuf;
     use std::rc::Rc;
 
+    use config::Config;
     use config::mock::MockConfig;
     use file_operations::FileOperations;
     use file_operations::Op;
@@ -69,17 +70,9 @@ mod tests {
         Hermit::new(config.clone())
     }
 
-    fn mock_config() -> MockConfig {
-        MockConfig {
-            root_path: PathBuf::from("/"),
-            allowed_shell_names: vec!["default".to_owned()],
-            current_shell: "default".to_owned(),
-        }
-    }
-
     #[test]
     fn returns_the_current_shell() {
-        let config = mock_config();
+        let config = MockConfig::new();
         let hermit = hermit(&config);
 
         let shell = hermit.current_shell().unwrap();
@@ -89,8 +82,8 @@ mod tests {
 
     #[test]
     fn can_set_the_current_shell() {
-        let mut config = mock_config();
-        config.current_shell = "current".to_owned();
+        let mut config = MockConfig::new();
+        config.set_current_shell_name("current");
         let mut hermit = hermit(&config);
 
         assert_eq!(hermit.current_shell().unwrap().name, "current");
@@ -100,7 +93,7 @@ mod tests {
 
     #[test]
     fn cant_set_the_current_shell_to_a_nonexistent_shell() {
-        let config = mock_config();
+        let config = MockConfig::new();
         let mut hermit = hermit(&config);
 
         assert_eq!(hermit.current_shell().unwrap().name, "default");
@@ -111,11 +104,7 @@ mod tests {
 
     #[test]
     fn can_initialize_a_new_shell() {
-        let config = MockConfig {
-            root_path: PathBuf::from(".hermit-config"),
-            allowed_shell_names: vec!["default".to_owned()],
-            current_shell: "default".to_owned(),
-        };
+        let config = MockConfig::with_root(".hermit-config", );
         let hermit = hermit(&config);
         let mut file_ops = FileOperations::rooted_at("/home/geoff");
 

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -83,11 +83,11 @@ mod tests {
     #[test]
     fn can_set_the_current_shell() {
         let mut config = MockConfig::new();
-        config.set_current_shell_name("current");
+        config.set_current_shell_name("current").expect("Setting shell name failed");
         let mut hermit = hermit(&config);
 
         assert_eq!(hermit.current_shell().unwrap().name, "current");
-        assert!(hermit.set_current_shell("default").is_ok());
+        hermit.set_current_shell("default").expect("Setting shell name failed");
         assert_eq!(hermit.current_shell().unwrap().name, "default");
     }
 
@@ -98,8 +98,8 @@ mod tests {
 
         assert_eq!(hermit.current_shell().unwrap().name, "default");
         let res = hermit.set_current_shell("non-existent");
-        assert!(res.is_err());
-        assert_eq!(res.err().unwrap(), Error::ShellDoesNotExist);
+        let err = res.expect_err("Shell should not exist");
+        assert_eq!(err, Error::ShellDoesNotExist);
     }
 
     #[test]

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -37,7 +37,7 @@ impl<T: Config> Hermit<T> {
     pub fn set_current_shell(&mut self, name: &str) -> Result<(), Error> {
         if self.config.shell_exists(name) {
             match Rc::get_mut(&mut self.config) {
-                Some(config) => config.set_current_shell_name(name).map_err(From::from),
+                Some(config) => config.set_current_shell_name(name).map_err(Error::from),
                 None => {
                     unreachable!(message::error_str("attempted to modify config while it was being used."))
                 }

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, result};
 use std::rc::Rc;
 
 use config::Config;
@@ -6,9 +6,7 @@ use file_operations::FileOperations;
 use message;
 use shell::Shell;
 
-#[derive(Copy,Clone)]
-#[derive(PartialEq,Eq)]
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     ShellDoesNotExist,
 }
@@ -18,6 +16,8 @@ impl From<io::Error> for Error {
         Error::ShellDoesNotExist
     }
 }
+
+pub type Result = result::Result<(), Error>;
 
 pub struct Hermit<T: Config> {
     config: Rc<T>,
@@ -34,7 +34,7 @@ impl<T: Config> Hermit<T> {
             .map(|shell_name| Shell::new(shell_name, self.config.clone()))
     }
 
-    pub fn set_current_shell(&mut self, name: &str) -> Result<(), Error> {
+    pub fn set_current_shell(&mut self, name: &str) -> Result {
         if self.config.shell_exists(name) {
             match Rc::get_mut(&mut self.config) {
                 Some(config) => config.set_current_shell_name(name).map_err(Error::from),

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,13 +29,15 @@ use file_operations::FileOperations;
 #[cfg(test)]
 mod test_helpers;
 
+use std::io;
+
 #[cfg_attr(rustfmt, rustfmt_skip)]
-fn main() {
+fn main() -> io::Result<()> {
     let app = make_app_config();
     let app_matches = app.get_matches();
 
     let hermit_root = env::get_hermit_dir().expect("Could not determine hermit root location.");
-    let fs_config = FsConfig::new(hermit_root);
+    let fs_config = FsConfig::new(hermit_root)?;
     let mut hermit = Hermit::new(fs_config);
 
     let home_dir = env::home_dir().expect("Could not determine home directory.");
@@ -54,6 +56,8 @@ fn main() {
     };
 
     report_errors(file_operations.commit());
+
+    Ok(())
 }
 
 fn report_errors(results: Vec<file_operations::Result>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 extern crate git2;
+extern crate walkdir;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,16 +23,14 @@ mod macros;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 use config::{Config, FsConfig};
-use hermit::Hermit;
+use hermit::{Hermit, Result};
 use file_operations::FileOperations;
 
 #[cfg(test)]
 mod test_helpers;
 
-use std::io;
-
 #[cfg_attr(rustfmt, rustfmt_skip)]
-fn main() -> io::Result<()> {
+fn main() -> Result {
     let app = make_app_config();
     let app_matches = app.get_matches();
 
@@ -53,7 +51,7 @@ fn main() -> io::Result<()> {
         ("status", Some(matches)) => handle_status (matches, &mut hermit, &mut file_operations),
         ("use",    Some(matches)) => handle_use    (matches, &mut hermit, &mut file_operations),
         _ => unreachable!(message::error_str("unknown subcommand passed"))
-    };
+    }?;
 
     report_errors(file_operations.commit());
 
@@ -102,8 +100,9 @@ subcommand!{
 
 fn handle_add<C: Config>(_matches: &ArgMatches,
                          _hermit: &mut Hermit<C>,
-                         _file_operations: &mut FileOperations) {
+                         _file_operations: &mut FileOperations) -> Result {
     println!("hermit add is not yet implemented");
+    Ok(())
 }
 
 
@@ -115,8 +114,9 @@ subcommand!{
 
 fn handle_clone<C: Config>(_matches: &ArgMatches,
                            _hermit: &mut Hermit<C>,
-                           _file_operations: &mut FileOperations) {
-    println!("hermit clone is not implemented yet.")
+                           _file_operations: &mut FileOperations) -> Result {
+    println!("hermit clone is not implemented yet.");
+    Ok(())
 }
 
 
@@ -128,8 +128,9 @@ subcommand!{
 
 fn handle_doctor<C: Config>(_matches: &ArgMatches,
                             _hermit: &mut Hermit<C>,
-                            _file_operations: &mut FileOperations) {
-    println!("hermit doctor is not implemented yet.")
+                            _file_operations: &mut FileOperations) -> Result {
+    println!("hermit doctor is not implemented yet.");
+    Ok(())
 }
 
 
@@ -142,8 +143,9 @@ subcommand!{
 
 fn handle_git<C: Config>(_matches: &ArgMatches,
                          _hermit: &mut Hermit<C>,
-                         _file_operations: &mut FileOperations) {
-    println!("hermit git is not implemented yet.")
+                         _file_operations: &mut FileOperations) -> Result {
+    println!("hermit git is not implemented yet.");
+    Ok(())
 }
 
 
@@ -157,9 +159,10 @@ subcommand!{
 
 fn handle_init<C: Config>(matches: &ArgMatches,
                           hermit: &mut Hermit<C>,
-                          file_operations: &mut FileOperations) {
+                          file_operations: &mut FileOperations) -> Result {
     let shell_name = matches.value_of("SHELL_NAME").unwrap_or("default");
     hermit.init_shell(file_operations, shell_name);
+    Ok(())
 }
 
 
@@ -171,8 +174,9 @@ subcommand!{
 
 fn handle_nuke<C: Config>(_matches: &ArgMatches,
                           _hermit: &mut Hermit<C>,
-                          _file_operations: &mut FileOperations) {
-    println!("hermit nuke is not implemented yet.")
+                          _file_operations: &mut FileOperations) -> Result {
+    println!("hermit nuke is not implemented yet.");
+    Ok(())
 }
 
 
@@ -184,8 +188,9 @@ subcommand!{
 
 fn handle_status<C: Config>(_matches: &ArgMatches,
                             _hermit: &mut Hermit<C>,
-                            _file_operations: &mut FileOperations) {
-    println!("hermit status is not implemented yet.")
+                            _file_operations: &mut FileOperations) -> Result {
+    println!("hermit status is not implemented yet.");
+    Ok(())
 }
 
 
@@ -197,6 +202,7 @@ subcommand!{
 
 fn handle_use<C: Config>(_matches: &ArgMatches,
                          _hermit: &mut Hermit<C>,
-                         _file_operations: &mut FileOperations) {
-    println!("hermit use is not implemented yet.")
+                         _file_operations: &mut FileOperations) -> Result {
+    println!("hermit use is not implemented yet.");
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result {
     let app_matches = app.get_matches();
 
     let hermit_root = env::get_hermit_dir().expect("Could not determine hermit root location.");
-    let fs_config = FsConfig::new(hermit_root)?;
+    let fs_config = FsConfig::new(hermit_root);
     let mut hermit = Hermit::new(fs_config);
 
     let home_dir = env::home_dir().expect("Could not determine home directory.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 extern crate git2;
-extern crate uuid;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,10 +210,12 @@ subcommand!{
   }
 }
 
-fn handle_inhabit<C: Config>(_matches: &ArgMatches,
-                             _hermit: &mut Hermit<C>,
-                             _file_operations: &mut FileOperations) -> Result {
-    not_implemented("inhabit")
+fn handle_inhabit<C: Config>(matches: &ArgMatches,
+                             hermit: &mut Hermit<C>,
+                             file_operations: &mut FileOperations) -> Result {
+    let shell_name = matches.value_of(SHELL_NAME_ARG).unwrap();
+    hermit.inhabit(file_operations, shell_name)?;
+    Ok(())
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,14 +56,14 @@ fn run() -> Result {
     let mut file_operations = FileOperations::rooted_at(home_dir);
 
     match app_matches.subcommand() {
-        ("add",    Some(matches)) => handle_add    (matches, &mut hermit, &mut file_operations),
-        ("clone",  Some(matches)) => handle_clone  (matches, &mut hermit, &mut file_operations),
-        ("doctor", Some(matches)) => handle_doctor (matches, &mut hermit, &mut file_operations),
-        ("git",    Some(matches)) => handle_git    (matches, &mut hermit, &mut file_operations),
-        ("init",   Some(matches)) => handle_init   (matches, &mut hermit, &mut file_operations),
-        ("nuke",   Some(matches)) => handle_nuke   (matches, &mut hermit, &mut file_operations),
-        ("status", Some(matches)) => handle_status (matches, &mut hermit, &mut file_operations),
-        ("use",    Some(matches)) => handle_use    (matches, &mut hermit, &mut file_operations),
+        ("add",     Some(matches)) => handle_add     (matches, &mut hermit, &mut file_operations),
+        ("clone",   Some(matches)) => handle_clone   (matches, &mut hermit, &mut file_operations),
+        ("doctor",  Some(matches)) => handle_doctor  (matches, &mut hermit, &mut file_operations),
+        ("git",     Some(matches)) => handle_git     (matches, &mut hermit, &mut file_operations),
+        ("init",    Some(matches)) => handle_init    (matches, &mut hermit, &mut file_operations),
+        ("nuke",    Some(matches)) => handle_nuke    (matches, &mut hermit, &mut file_operations),
+        ("status",  Some(matches)) => handle_status  (matches, &mut hermit, &mut file_operations),
+        ("inhabit", Some(matches)) => handle_inhabit (matches, &mut hermit, &mut file_operations),
         _ => unreachable!(message::error_str("unknown subcommand passed"))
     }?;
 
@@ -97,7 +97,7 @@ fn make_app_config<'a, 'b>() -> App<'a, 'b> {
     let app = add_init_subcommand(app);
     let app = add_nuke_subcommand(app);
     let app = add_status_subcommand(app);
-    let app = add_use_subcommand(app);
+    let app = add_inhabit_subcommand(app);
 
     app
 }
@@ -204,15 +204,15 @@ fn handle_status<C: Config>(_matches: &ArgMatches,
 
 
 subcommand!{
-  add_use_subcommand("use") {
+  add_inhabit_subcommand("inhabit") {
     about("Switch to using a different hermit shell")
   }
 }
 
-fn handle_use<C: Config>(_matches: &ArgMatches,
-                         _hermit: &mut Hermit<C>,
-                         _file_operations: &mut FileOperations) -> Result {
-    not_implemented("use")
+fn handle_inhabit<C: Config>(_matches: &ArgMatches,
+                             _hermit: &mut Hermit<C>,
+                             _file_operations: &mut FileOperations) -> Result {
+    not_implemented("inhabit")
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,10 @@ use file_operations::FileOperations;
 #[cfg(test)]
 mod test_helpers;
 
+
+const SHELL_NAME_ARG: &str = "SHELL_NAME";
+
+
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn main() -> Result {
     let app = make_app_config();
@@ -153,14 +157,14 @@ subcommand!{
   add_init_subcommand("init") {
     about("Create a new hermit shell called SHELL_NAME. If no shell name \
            is given, \"default\" is used.")
-    arg(Arg::with_name("SHELL_NAME").help("The name of the shell to be created."))
+    arg(shell_name_arg("The name of the shell to be created."))
   }
 }
 
 fn handle_init<C: Config>(matches: &ArgMatches,
                           hermit: &mut Hermit<C>,
                           file_operations: &mut FileOperations) -> Result {
-    let shell_name = matches.value_of("SHELL_NAME").unwrap_or("default");
+    let shell_name = matches.value_of(SHELL_NAME_ARG).unwrap();
     hermit.init_shell(file_operations, shell_name);
     Ok(())
 }
@@ -205,4 +209,15 @@ fn handle_use<C: Config>(_matches: &ArgMatches,
                          _file_operations: &mut FileOperations) -> Result {
     println!("hermit use is not implemented yet.");
     Ok(())
+}
+
+
+// **************************************************
+// Clap arg utility functions
+// **************************************************
+
+fn shell_name_arg<'a, 'b>(message: &'static str) -> Arg<'a, 'b> {
+    Arg::with_name(SHELL_NAME_ARG)
+        .default_value("default")
+        .help(message)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 #![warn(missing_docs)]
 extern crate clap;
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 extern crate git2;
 extern crate uuid;
 
@@ -16,8 +19,6 @@ mod file_operations;
 
 #[macro_use]
 mod macros;
-
-use std::error::Error;
 
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
@@ -49,7 +50,7 @@ fn main() {
         ("nuke",   Some(matches)) => handle_nuke   (matches, &mut hermit, &mut file_operations),
         ("status", Some(matches)) => handle_status (matches, &mut hermit, &mut file_operations),
         ("use",    Some(matches)) => handle_use    (matches, &mut hermit, &mut file_operations),
-        _ => unreachable!(message::error("unknown subcommand passed"))
+        _ => unreachable!(message::error_str("unknown subcommand passed"))
     };
 
     report_errors(file_operations.commit());
@@ -59,7 +60,7 @@ fn report_errors(results: Vec<file_operations::Result>) {
     for result in results {
         match result {
             Ok(()) => (),
-            Err(e) => println!("{}", message::error(e.description())),
+            Err(e) => println!("{}", message::error(e)),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,12 @@ mod file_operations;
 #[macro_use]
 mod macros;
 
+use std::process;
+
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 use config::{Config, FsConfig};
-use hermit::{Hermit, Result};
+use hermit::{Error, Hermit, Result};
 use file_operations::FileOperations;
 
 #[cfg(test)]
@@ -32,9 +34,18 @@ mod test_helpers;
 
 const SHELL_NAME_ARG: &str = "SHELL_NAME";
 
+fn main() {
+    match run() {
+        Ok(()) => (),
+        Err(err) => {
+            eprintln!("{}: {}", env::get_program_name(), err);
+            process::exit(1)
+        },
+    }
+}
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-fn main() -> Result {
+fn run() -> Result {
     let app = make_app_config();
     let app_matches = app.get_matches();
 
@@ -105,8 +116,7 @@ subcommand!{
 fn handle_add<C: Config>(_matches: &ArgMatches,
                          _hermit: &mut Hermit<C>,
                          _file_operations: &mut FileOperations) -> Result {
-    println!("hermit add is not yet implemented");
-    Ok(())
+    not_implemented("add")
 }
 
 
@@ -119,8 +129,7 @@ subcommand!{
 fn handle_clone<C: Config>(_matches: &ArgMatches,
                            _hermit: &mut Hermit<C>,
                            _file_operations: &mut FileOperations) -> Result {
-    println!("hermit clone is not implemented yet.");
-    Ok(())
+    not_implemented("clone")
 }
 
 
@@ -133,8 +142,7 @@ subcommand!{
 fn handle_doctor<C: Config>(_matches: &ArgMatches,
                             _hermit: &mut Hermit<C>,
                             _file_operations: &mut FileOperations) -> Result {
-    println!("hermit doctor is not implemented yet.");
-    Ok(())
+    not_implemented("doctor")
 }
 
 
@@ -148,8 +156,7 @@ subcommand!{
 fn handle_git<C: Config>(_matches: &ArgMatches,
                          _hermit: &mut Hermit<C>,
                          _file_operations: &mut FileOperations) -> Result {
-    println!("hermit git is not implemented yet.");
-    Ok(())
+    not_implemented("git")
 }
 
 
@@ -179,8 +186,7 @@ subcommand!{
 fn handle_nuke<C: Config>(_matches: &ArgMatches,
                           _hermit: &mut Hermit<C>,
                           _file_operations: &mut FileOperations) -> Result {
-    println!("hermit nuke is not implemented yet.");
-    Ok(())
+    not_implemented("nuke")
 }
 
 
@@ -193,8 +199,7 @@ subcommand!{
 fn handle_status<C: Config>(_matches: &ArgMatches,
                             _hermit: &mut Hermit<C>,
                             _file_operations: &mut FileOperations) -> Result {
-    println!("hermit status is not implemented yet.");
-    Ok(())
+    not_implemented("status")
 }
 
 
@@ -207,17 +212,20 @@ subcommand!{
 fn handle_use<C: Config>(_matches: &ArgMatches,
                          _hermit: &mut Hermit<C>,
                          _file_operations: &mut FileOperations) -> Result {
-    println!("hermit use is not implemented yet.");
-    Ok(())
+    not_implemented("use")
 }
 
 
 // **************************************************
-// Clap arg utility functions
+// Utility functions
 // **************************************************
 
 fn shell_name_arg<'a, 'b>(message: &'static str) -> Arg<'a, 'b> {
     Arg::with_name(SHELL_NAME_ARG)
         .default_value("default")
         .help(message)
+}
+
+fn not_implemented(name: &'static str) -> Result {
+    Err(Error::SubcommandNotImplemented(name))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ fn report_errors(results: Vec<file_operations::Result>) {
     }
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
 fn make_app_config<'a, 'b>() -> App<'a, 'b> {
     let app = App::new("hermit")
         .version(env!("CARGO_PKG_VERSION"))

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,5 +1,11 @@
+use failure::{self, Error};
+
 use env;
 
-pub fn error(details: &str) -> String {
-    format!("{}: error: {}", env::get_program_name(), details)
+pub fn error_str<T: 'static + Into<String>>(details: T) -> String {
+    error(failure::err_msg(details.into()))
+}
+
+pub fn error(failure: impl Into<Error>) -> String {
+    format!("{}: error: {}", env::get_program_name(), failure.into())
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -40,6 +40,7 @@ impl<T: Config> Shell<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_helpers::ops::*;
 
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
@@ -97,10 +98,6 @@ mod tests {
 
         let expected_path = root_path.join("shells").join("default").join(".bashrc");
         assert_eq!(s.path_for(".bashrc"), expected_path);
-    }
-
-    fn link_op_for(root_path: &PathBuf, op_root: &PathBuf, filename: &str) -> Op {
-        Op::Link { target: root_path.join(filename), path: op_root.join(filename) }
     }
 
     #[test]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -30,7 +30,7 @@ impl<T: Config> Shell<T> {
 #[cfg(test)]
 mod tests {
 
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::rc::Rc;
 
     use config::mock::MockConfig;
@@ -41,14 +41,9 @@ mod tests {
         PathBuf::from(path_str)
     }
 
-    fn std_mock_config() -> Rc<MockConfig> {
-        let root_path = PathBuf::from("/");
-        mock_config(root_path)
-    }
-
-    fn mock_config(root_path: PathBuf) -> Rc<MockConfig> {
+    fn mock_config<P: AsRef<Path>>(root_path: P) -> Rc<MockConfig> {
         Rc::new(MockConfig {
-            root_path: root_path,
+            root_path: PathBuf::from(root_path.as_ref()),
             allowed_shell_names: vec!["default".to_owned()],
             current_shell: "default".to_owned(),
         })
@@ -56,26 +51,25 @@ mod tests {
 
     #[test]
     fn has_a_name() {
-        let config = std_mock_config();
+        let config = mock_config("/");
         let s = Shell::new("my_shell", config);
         assert_eq!(s.name, "my_shell");
     }
 
     #[test]
     fn has_a_string_name() {
-        let config = std_mock_config();
+        let config = mock_config("/");
         let s = Shell::new(String::from("my_shell"), config);
         assert_eq!(s.name, "my_shell");
     }
 
     #[test]
     fn can_resolve_its_path() {
-        let root_path = root_path("/Users/geoff/.config/hermit");
+        let root_path = root_path("/some/random/path");
         let config = mock_config(root_path.clone());
         let s = Shell::new("default", config);
 
-        let expected_path = root_path.join("shells")
-            .join("default");
+        let expected_path = root_path.join("shells").join("default");
         assert_eq!(s.root_path(), expected_path);
     }
 
@@ -85,8 +79,7 @@ mod tests {
         let config = mock_config(root_path.clone());
         let s = Shell::new("default", config);
 
-        let expected_path = root_path.join("shells")
-            .join("default");
+        let expected_path = root_path.join("shells").join("default");
         assert_eq!(s.path_for(""), expected_path);
     }
 
@@ -96,9 +89,7 @@ mod tests {
         let config = mock_config(root_path.clone());
         let s = Shell::new("default", config);
 
-        let expected_path = root_path.join("shells")
-            .join("default")
-            .join(".bashrc");
+        let expected_path = root_path.join("shells").join("default").join(".bashrc");
         assert_eq!(s.path_for(".bashrc"), expected_path);
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -42,11 +42,7 @@ mod tests {
     }
 
     fn mock_config<P: AsRef<Path>>(root_path: P) -> Rc<MockConfig> {
-        Rc::new(MockConfig {
-            root_path: PathBuf::from(root_path.as_ref()),
-            allowed_shell_names: vec!["default".to_owned()],
-            current_shell: "default".to_owned(),
-        })
+        Rc::new(MockConfig::with_root(root_path))
     }
 
     #[test]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -10,10 +10,8 @@ pub struct Shell<T: Config> {
 
 impl<T: Config> Shell<T> {
     pub fn new(name: impl Into<String>, config: Rc<T>) -> Shell<T> {
-        Shell {
-            name: name.into(),
-            config: config,
-        }
+        let name = name.into();
+        Shell { name, config }
     }
 
     pub fn root_path(&self) -> PathBuf {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -9,9 +9,7 @@ pub struct Shell<T: Config> {
 }
 
 impl<T: Config> Shell<T> {
-    pub fn new<S>(name: S, config: Rc<T>) -> Shell<T>
-        where S: Into<String>
-    {
+    pub fn new(name: impl Into<String>, config: Rc<T>) -> Shell<T> {
         Shell {
             name: name.into(),
             config: config,

--- a/src/test_helpers/filesystem.rs
+++ b/src/test_helpers/filesystem.rs
@@ -2,8 +2,6 @@ use std::{fs, io};
 use std::io::Write;
 use std::path::PathBuf;
 
-use uuid::Uuid;
-
 pub fn clean_up(test_root: &PathBuf) {
     if test_root.exists() && test_root.is_dir() {
         match fs::remove_dir_all(test_root) {
@@ -24,8 +22,7 @@ pub fn clean_up(test_root: &PathBuf) {
 }
 
 pub fn set_up(suffix: &str) -> PathBuf {
-    let random_uuid = Uuid::new_v4();
-    let suffix = format!("{}-{}", suffix, random_uuid);
+    let suffix = format!("fs-tests-{}", suffix);
     let test_root = PathBuf::from("target").join(&suffix);
     clean_up(&test_root);
 

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -1,1 +1,2 @@
 pub mod filesystem;
+pub mod ops;

--- a/src/test_helpers/ops.rs
+++ b/src/test_helpers/ops.rs
@@ -1,0 +1,6 @@
+use std::path::PathBuf;
+use file_operations::Op;
+
+pub fn link_op_for(root_path: &PathBuf, op_root: &PathBuf, filename: &str) -> Op {
+    Op::Link { target: root_path.join(filename), path: op_root.join(filename) }
+}


### PR DESCRIPTION
Fixes #105, fixes #116, fixes #117 

### Summary

The primary code addition here is an extension to the `Config` trait.  We add a method `shell_files` which returns an iterator (sort of) over all the files in the shell.

The reasoning behind this is to continue using the `Config` trait as the abstraction break for filesystem access of hermit configuration.

Implementing this method and designing the trait interface correctly took quite a while, and a lot of different approaches were explored.  I think the current solution is pretty clean, and it allows for really trivial mocking of the `shell_files` method by having the `MockConfig` struct return a `Vec<PathBuf>`. This simplicity of mocking is mostly what drove the design decision to have the trait actually return an `IntoIterator` rather than an `Iterator`.  This choice also made it easier to write the "real" filesystem-accessing implementation.

#### Dependency Addition

A note on the dependency that is added: [walkdir](https://github.com/BurntSushi/walkdir).

This crate looks to be pretty robust, and has all the options we need.  It's also written by a fairly prominent Rustacean (BurntSushi) who basically (through his blog posts) taught me much of what I know about Rust, particularly how to do ergonomic and effective error handling.  Furthermore, this crate is the product of him attempting to fix/complete/stabilize the [unstable directory walking implementation in std](https://doc.rust-lang.org/1.5.0/std/fs/fn.walk_dir.html).

TL;DR I think he knows what he's doing :smile: 