### PR TITLE
157 add integration testing

### DIFF
--- a/lib/hermit-profile
+++ b/lib/hermit-profile
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Summary: Print out the name of the profile currently in use
+# Usage: hermit profile
+
+# Copyright 2018, Geoff Shannon
+
+# This file is part of Hermit.
+
+# Hermit is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Hermit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Hermit. If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+[ -n "$HERMIT_DEBUG" ] && set -x
+
+if [ "$1" = "--complete" ]; then
+    exit
+fi
+
+pushd $HERMIT_ROOT 2>&1 >/dev/null
+
+echo $(git config "hermit.current")
+
+popd 2>&1 >/dev/null

--- a/runtests.sh
+++ b/runtests.sh
@@ -9,6 +9,9 @@ cargo build --verbose
 cargo test  --verbose
 
 export TESTDIR=".test-place"
+
+# Integration test shell hermit
+export PROFILE_DIR_NAME=profiles
 export TEST_PROFILE_NAME=default
 
 printf '\n\033[0;33m%s\033[0m\n' "Running tests in test"

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+function run_tests() {
+    export TEST_PROFILE_NAME=$1
+    printf '\n\033[0;33m%s\033[0m\n' "Running tests in test with profile name $TEST_PROFILE_NAME"
+    $URCHIN test/
+}
+
 URCHIN=$(which urchin)
 URCHIN=${URCHIN:-/tmp/urchin}
 
@@ -11,13 +17,11 @@ cargo test  --verbose
 export TESTDIR=".test-place"
 
 # Integration test shell hermit
+
 export PROFILE_DIR_NAME=profiles
-export TEST_PROFILE_NAME=default
 
-printf '\n\033[0;33m%s\033[0m\n' "Running tests in test"
-$URCHIN test/
+RANDOM_PROFILE_NAME=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 
-export TEST_PROFILE_NAME=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
-printf '\n\033[0;33m%s\033[0m\n' "Running tests in test with profile name $TEST_PROFILE_NAME"
+run_tests default
 
-$URCHIN test/
+run_tests ${RANDOM_PROFILE_NAME}

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+function ignore_tests() {
+    for file in ${IGNORE_SUBCOMMAND_LIST[*]}
+    do
+        mv test/{,.}${file}
+    done
+}
+
+function restore_tests() {
+    for file in ${IGNORE_SUBCOMMAND_LIST[*]}
+    do
+        mv test/{.,}${file}
+    done
+}
+
 function run_tests() {
     export TEST_PROFILE_NAME=$1
     printf '\n\033[0;33m%s\033[0m\n' "Running tests in test with profile name $TEST_PROFILE_NAME"
@@ -19,8 +33,26 @@ export TESTDIR=".test-place"
 # Integration test shell hermit
 
 export PROFILE_DIR_NAME=profiles
+export USE_COMMAND=use
 
 RANDOM_PROFILE_NAME=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+
+run_tests default
+
+run_tests ${RANDOM_PROFILE_NAME}
+
+
+# Integration test Rust hermit
+
+export USE_HERMIT_RS=true
+export PROFILE_DIR_NAME=shells
+export USE_COMMAND=inhabit
+
+IGNORE_SUBCOMMAND_LIST=(add clone commands completions doctor git use link unlink utilities)
+
+ignore_tests
+
+trap restore_tests EXIT
 
 run_tests default
 

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -38,23 +38,22 @@ impl<T: Config> Hermit<T> {
             .map(|shell_name| Shell::new(shell_name, self.config.clone()))
     }
 
-    pub fn set_current_shell(&mut self, name: &str) -> Result {
-        if self.config.shell_exists(name) {
-            match Rc::get_mut(&mut self.config) {
-                Some(config) => config.set_current_shell_name(name).map_err(Error::from),
-                None => {
-                    unreachable!(message::error_str("attempted to modify config while it was being used."))
-                }
+    fn set_current_shell(&mut self, name: &str) -> Result {
+        match Rc::get_mut(&mut self.config) {
+            Some(config) => config.set_current_shell_name(name).map_err(Error::from),
+            None => {
+                unreachable!(message::error_str("attempted to modify config while it was being used."))
             }
-        } else {
-            Err(Error::ShellDoesNotExist)
         }
     }
 
-    pub fn init_shell(&self, file_ops: &mut FileOperations, name: &str) {
-        let new_shell = Shell::new(name, self.config.clone());
-        let path = new_shell.root_path();
-        file_ops.create_git_repo(path);
+    pub fn init_shell(&mut self, file_ops: &mut FileOperations, name: &str) -> Result {
+        self.set_current_shell(name)?;
+        if let Some(new_shell) = self.current_shell() {
+            let path = new_shell.root_path();
+            file_ops.create_git_repo(path);
+        }
+        Ok(())
     }
 
     pub fn inhabit(&mut self, file_ops: &mut FileOperations, name: &str) -> Result {
@@ -114,23 +113,12 @@ mod tests {
     }
 
     #[test]
-    fn cant_set_the_current_shell_to_a_nonexistent_shell() {
-        let config = MockConfig::new();
-        let mut hermit = hermit(&config);
-
-        assert_eq!(hermit.current_shell().unwrap().name, "default");
-        let res = hermit.set_current_shell("non-existent");
-        let err = res.expect_err("Shell should not exist");
-        assert_eq!(err, Error::ShellDoesNotExist);
-    }
-
-    #[test]
     fn can_initialize_a_new_shell() {
         let config = MockConfig::with_root(".hermit-config", );
-        let hermit = hermit(&config);
+        let mut hermit = hermit(&config);
         let mut file_ops = FileOperations::rooted_at("/home/geoff");
 
-        hermit.init_shell(&mut file_ops, "new-one");
+        hermit.init_shell(&mut file_ops, "new-one").expect("Init shell failed");
         let first_op = &file_ops.operations()[0];
         assert_eq!(*first_op,
                    Op::GitInit(PathBuf::from("/home/geoff/.hermit-config/shells/new-one")));

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ fn run() -> Result {
         ("git",     Some(matches)) => handle_git     (matches, &mut hermit, &mut file_operations),
         ("init",    Some(matches)) => handle_init    (matches, &mut hermit, &mut file_operations),
         ("nuke",    Some(matches)) => handle_nuke    (matches, &mut hermit, &mut file_operations),
+        ("shell",   Some(matches)) => handle_shell   (matches, &mut hermit, &mut file_operations),
         ("status",  Some(matches)) => handle_status  (matches, &mut hermit, &mut file_operations),
         ("inhabit", Some(matches)) => handle_inhabit (matches, &mut hermit, &mut file_operations),
         _ => unreachable!(message::error_str("unknown subcommand passed"))
@@ -97,6 +98,7 @@ fn make_app_config<'a, 'b>() -> App<'a, 'b> {
     let app = add_git_subcommand(app);
     let app = add_init_subcommand(app);
     let app = add_nuke_subcommand(app);
+    let app = add_shell_subcommand(app);
     let app = add_status_subcommand(app);
     let app = add_inhabit_subcommand(app);
 
@@ -192,9 +194,27 @@ fn handle_nuke<C: Config>(_matches: &ArgMatches,
 
 
 subcommand!{
-  add_status_subcommand("status") {
-    about("Display the status of your hermit shell")
+  add_shell_subcommand("shell") {
+    about("Display the shell you are currently inhabiting")
   }
+}
+
+fn handle_shell<C: Config>(_matches: &ArgMatches,
+                           hermit: &mut Hermit<C>,
+                           _file_operations: &mut FileOperations) -> Result {
+    if let Some(shell) = hermit.current_shell() {
+        println!("{}", shell.name);
+    } else {
+        eprintln!("{}", message::error_str("no active shell"));
+    }
+    Ok(())
+}
+
+
+subcommand!{
+    add_status_subcommand("status") {
+        about("Display the status of your hermit shell")
+    }
 }
 
 fn handle_status<C: Config>(_matches: &ArgMatches,

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn handle_init<C: Config>(matches: &ArgMatches,
                           hermit: &mut Hermit<C>,
                           file_operations: &mut FileOperations) -> Result {
     let shell_name = matches.value_of(SHELL_NAME_ARG).unwrap();
-    hermit.init_shell(file_operations, shell_name);
+    hermit.init_shell(file_operations, shell_name)?;
     Ok(())
 }
 

--- a/test/.environment
+++ b/test/.environment
@@ -19,17 +19,22 @@ touch $PROFILE
 git config --global user.name "Foo Bar"
 git config --global user.email "baz@foo.bar"
 
-# On Travis, hermit is a shallow clone, so it can't officially be cloned from
-# So we remove the shallow marker if it's there
-if [ -f ../../.git/shallow ]
+if [ "${USE_HERMIT_RS}" != "true" ]
 then
-    rm ../../.git/shallow
+    # On Travis, hermit is a shallow clone, so it can't officially be cloned from
+    # So we remove the shallow marker if it's there
+    if [ -f ../../.git/shallow ]
+    then
+        rm ../../.git/shallow
+    fi
+
+    # Install hermit into testing environment via git clone
+    git clone ../../ $HERMIT_ROOT
+else
+    mkdir -p $HERMIT_ROOT/bin
+    cp ../../target/debug/hermit $HERMIT_ROOT/bin
 fi
 
-# Install hermit into testing environment via git clone
-git clone ../../ $HERMIT_ROOT
-
 SOURCE_STR="export PATH=\"\$HERMIT_ROOT/bin:\$PATH\" # This loads Hermit"
-
 echo "" >> $PROFILE
 echo $SOURCE_STR >> $PROFILE

--- a/test/.environment
+++ b/test/.environment
@@ -1,6 +1,10 @@
 # Make home the full path to TESTDIR
 export HOME=${PWD}/${TESTDIR}
 
+# Override the potential user setting of HERMIT_ROOT for test
+# correctness
+export HERMIT_ROOT="$HOME/.hermit"
+
 if [ ! -d "${HOME}" ]
 then
   echo "The faked home directory '$HOME' does not exist."
@@ -23,12 +27,9 @@ then
 fi
 
 # Install hermit into testing environment via git clone
-git clone ../../ $HOME/.hermit
+git clone ../../ $HERMIT_ROOT
 
-# Override the potential user setting of HERMIT_ROOT for test
-# correctness
-export HERMIT_ROOT="$HOME/.hermit"
+SOURCE_STR="export PATH=\"\$HERMIT_ROOT/bin:\$PATH\" # This loads Hermit"
 
-SOURCE_STR="export PATH=\"\$HOME/.hermit/bin:\$PATH\" # This loads Hermit"
 echo "" >> $PROFILE
 echo $SOURCE_STR >> $PROFILE

--- a/test/add/directory
+++ b/test/add/directory
@@ -2,7 +2,7 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit init $TEST_PROFILE_NAME
+$HERMIT_ROOT/bin/hermit init $TEST_PROFILE_NAME
 
 DIR=the-test-dir
 
@@ -13,11 +13,11 @@ echo other stuff ands > $HOME/$DIR/bar
 echo and stuff things > $HOME/$DIR/baz
 echo and things stuff > $HOME/$DIR/qux
 
-$HOME/.hermit/bin/hermit add $HOME/$DIR
+$HERMIT_ROOT/bin/hermit add $HOME/$DIR
 
 RET=$?
 
-if [ \! -d $HOME/.hermit/profiles/$TEST_PROFILE_NAME/$DIR ]
+if [ \! -d $HERMIT_ROOT/$PROFILE_DIR_NAME/$TEST_PROFILE_NAME/$DIR ]
 then
     echo "There is no directory $DIR inside the profile."
     exit 1
@@ -26,7 +26,7 @@ fi
 for file in foo bar baz qux
 do
 
-    if [ \! -f $HOME/.hermit/profiles/$TEST_PROFILE_NAME/$DIR/$file ]
+    if [ \! -f $HERMIT_ROOT/$PROFILE_DIR_NAME/$TEST_PROFILE_NAME/$DIR/$file ]
     then
         echo "$file is not present inside $DIR in the profile."
         exit 1

--- a/test/add/file
+++ b/test/add/file
@@ -2,7 +2,7 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit init $TEST_PROFILE_NAME
+$HERMIT_ROOT/bin/hermit init $TEST_PROFILE_NAME
 
 FILE=.testfile
 
@@ -16,11 +16,11 @@ pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
 culpa qui officia deserunt mollit anim id est laborum."
 EOF
 
-$HOME/.hermit/bin/hermit add $HOME/$FILE
+$HERMIT_ROOT/bin/hermit add $HOME/$FILE
 
 RET=$?
 
-if [ \! -f $HOME/.hermit/profiles/$TEST_PROFILE_NAME/$FILE ]
+if [ \! -f $HERMIT_ROOT/$PROFILE_DIR_NAME/$TEST_PROFILE_NAME/$FILE ]
 then
     echo "There is no actual file $FILE in the profile."
     exit 1

--- a/test/add/subdir-add
+++ b/test/add/subdir-add
@@ -2,7 +2,7 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit init $TEST_PROFILE_NAME
+$HERMIT_ROOT/bin/hermit init $TEST_PROFILE_NAME
 
 SUBDIR=.interior-dir
 FILE=.testfile
@@ -21,7 +21,7 @@ EOF
 
 pushd $HOME/$SUBDIR >/dev/null 2>&1
 
-$HOME/.hermit/bin/hermit add $FILE
+$HERMIT_ROOT/bin/hermit add $FILE
 
 RET=$?
 
@@ -31,15 +31,15 @@ echo "Contents of $SUBDIR"
 find $HOME/$SUBDIR
 echo
 echo "Contents of hermit profile"
-find $HOME/.hermit/profiles/$TEST_PROFILE_NAME -type d -name .git -prune -o -print
+find $HERMIT_ROOT/$PROFILE_DIR_NAME/$TEST_PROFILE_NAME -type d -name .git -prune -o -print
 
-if [ \! -d $HOME/.hermit/profiles/$TEST_PROFILE_NAME/$SUBDIR ]
+if [ \! -d $HERMIT_ROOT/$PROFILE_DIR_NAME/$TEST_PROFILE_NAME/$SUBDIR ]
 then
     echo "The subdirectory $SUBDIR is missing from the profile."
     exit 1
 fi
 
-if [ \! -f $HOME/.hermit/profiles/$TEST_PROFILE_NAME/$SUBDIR/$FILE ]
+if [ \! -f $HERMIT_ROOT/$PROFILE_DIR_NAME/$TEST_PROFILE_NAME/$SUBDIR/$FILE ]
 then
     echo "There is no actual file $FILE in the profile."
     exit 1

--- a/test/add/symlink
+++ b/test/add/symlink
@@ -2,16 +2,16 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit init $TEST_PROFILE_NAME
+$HERMIT_ROOT/bin/hermit init $TEST_PROFILE_NAME
 
 FILE=.testfile
 ln -s nowhere $HOME/$FILE
 
-$HOME/.hermit/bin/hermit add $HOME/$FILE
+$HERMIT_ROOT/bin/hermit add $HOME/$FILE
 
 RET=$?
 
-if [ -f $HOME/.hermit/profiles/$TEST_PROFILE_NAME/$FILE ]
+if [ -f $HERMIT_ROOT/$PROFILE_DIR_NAME/$TEST_PROFILE_NAME/$FILE ]
 then
     echo "The symlink was erroneously added to the profile."
     exit 1

--- a/test/clone/.do-clone
+++ b/test/clone/.do-clone
@@ -30,7 +30,7 @@ then
     exit 1
 fi
 
-NEW_PROFILE=$($HERMIT_ROOT/bin/hermit profile)
+NEW_PROFILE=$($HERMIT_ROOT/bin/hermit ${PROFILE_DIR_NAME%s})
 
 if [ "$CHECK_PROFILE" \!= "$NEW_PROFILE" ]
 then

--- a/test/clone/.do-clone
+++ b/test/clone/.do-clone
@@ -3,11 +3,11 @@
 # Run hermit clone with appropriate arguments
 if [ -z "$NAMED_PROFILE" ]
 then
-    $HOME/.hermit/bin/hermit clone $CLONE_REPO
+    $HERMIT_ROOT/bin/hermit clone $CLONE_REPO
     RET=$?
     CHECK_PROFILE=default
 else
-    $HOME/.hermit/bin/hermit clone $CLONE_REPO $NAMED_PROFILE
+    $HERMIT_ROOT/bin/hermit clone $CLONE_REPO $NAMED_PROFILE
     RET=$?
     CHECK_PROFILE=$NAMED_PROFILE
 fi
@@ -18,19 +18,19 @@ then
     exit 1
 fi
 
-if [ \! -d $HOME/.hermit/profiles/$CHECK_PROFILE ]
+if [ \! -d $HERMIT_ROOT/$PROFILE_DIR_NAME/$CHECK_PROFILE ]
 then
     echo "Profile $CHECK_PROFILE does not exist after running clone."
     exit 1
 fi
 
-if [ \! -d $HOME/.hermit/profiles/$CHECK_PROFILE/.git ]
+if [ \! -d $HERMIT_ROOT/$PROFILE_DIR_NAME/$CHECK_PROFILE/.git ]
 then
     echo "Profile $CHECK_PROFILE is not a git repository."
     exit 1
 fi
 
-pushd $HOME/.hermit 2>&1 >/dev/null
+pushd $HERMIT_ROOT 2>&1 >/dev/null
 NEW_PROFILE=$(git config "hermit.current")
 popd 2>&1 >/dev/null
 

--- a/test/clone/.do-clone
+++ b/test/clone/.do-clone
@@ -30,9 +30,7 @@ then
     exit 1
 fi
 
-pushd $HERMIT_ROOT 2>&1 >/dev/null
-NEW_PROFILE=$(git config "hermit.current")
-popd 2>&1 >/dev/null
+NEW_PROFILE=$($HERMIT_ROOT/bin/hermit profile)
 
 if [ "$CHECK_PROFILE" \!= "$NEW_PROFILE" ]
 then

--- a/test/commands/sanity-check
+++ b/test/commands/sanity-check
@@ -2,4 +2,4 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit commands
+$HERMIT_ROOT/bin/hermit commands

--- a/test/completions/sanity-check
+++ b/test/completions/sanity-check
@@ -2,4 +2,4 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit completions completions
+$HERMIT_ROOT/bin/hermit completions completions

--- a/test/doctor/sanity-check
+++ b/test/doctor/sanity-check
@@ -2,4 +2,4 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit doctor
+$HERMIT_ROOT/bin/hermit doctor

--- a/test/git/version
+++ b/test/git/version
@@ -2,8 +2,8 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit init $TEST_PROFILE_NAME
-$HOME/.hermit/bin/hermit git --version
+$HERMIT_ROOT/bin/hermit init $TEST_PROFILE_NAME
+$HERMIT_ROOT/bin/hermit git --version
 
 RET=$?
 

--- a/test/git/working-dir
+++ b/test/git/working-dir
@@ -2,11 +2,11 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit init $TEST_PROFILE_NAME
+$HERMIT_ROOT/bin/hermit init $TEST_PROFILE_NAME
 
-DIR="$($HOME/.hermit/bin/hermit git rev-parse --show-toplevel | tail -n 1)"
+DIR="$($HERMIT_ROOT/bin/hermit git rev-parse --show-toplevel | tail -n 1)"
 
-if [ "$DIR" = $HOME/.hermit/profiles/$TEST_PROFILE_NAME ]; then
+if [ "$DIR" = $HERMIT_ROOT/$PROFILE_DIR_NAME/$TEST_PROFILE_NAME ]; then
   exit 0
 else
   exit 1

--- a/test/help/sanity-check
+++ b/test/help/sanity-check
@@ -2,4 +2,4 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit help
+$HERMIT_ROOT/bin/hermit help

--- a/test/init/.do-init
+++ b/test/init/.do-init
@@ -30,7 +30,7 @@ then
     exit 1
 fi
 
-NEW_PROFILE=$($HERMIT_ROOT/bin/hermit profile)
+NEW_PROFILE=$($HERMIT_ROOT/bin/hermit ${PROFILE_DIR_NAME%s})
 
 if [ "$CHECK_PROFILE" \!= "$NEW_PROFILE" ]
 then

--- a/test/init/.do-init
+++ b/test/init/.do-init
@@ -30,9 +30,7 @@ then
     exit 1
 fi
 
-pushd $HERMIT_ROOT 2>&1 >/dev/null
-NEW_PROFILE=$(git config "hermit.current")
-popd 2>&1 >/dev/null
+NEW_PROFILE=$($HERMIT_ROOT/bin/hermit profile)
 
 if [ "$CHECK_PROFILE" \!= "$NEW_PROFILE" ]
 then

--- a/test/init/.do-init
+++ b/test/init/.do-init
@@ -3,11 +3,11 @@
 # Run hermit init with appropriate arguments
 if [ -z "$NAMED_PROFILE" ]
 then
-    $HOME/.hermit/bin/hermit init
+    $HERMIT_ROOT/bin/hermit init
     RET=$?
     CHECK_PROFILE=default
 else
-    $HOME/.hermit/bin/hermit init $NAMED_PROFILE
+    $HERMIT_ROOT/bin/hermit init $NAMED_PROFILE
     RET=$?
     CHECK_PROFILE=$NAMED_PROFILE
 fi
@@ -18,19 +18,19 @@ then
     exit 1
 fi
 
-if [ \! -d $HOME/.hermit/profiles/$CHECK_PROFILE ]
+if [ \! -d $HERMIT_ROOT/$PROFILE_DIR_NAME/$CHECK_PROFILE ]
 then
     echo "Profile $CHECK_PROFILE does not exist after running init."
     exit 1
 fi
 
-if [ \! -d $HOME/.hermit/profiles/$CHECK_PROFILE/.git ]
+if [ \! -d $HERMIT_ROOT/$PROFILE_DIR_NAME/$CHECK_PROFILE/.git ]
 then
     echo "Profile $CHECK_PROFILE is not a git repository."
     exit 1
 fi
 
-pushd $HOME/.hermit 2>&1 >/dev/null
+pushd $HERMIT_ROOT 2>&1 >/dev/null
 NEW_PROFILE=$(git config "hermit.current")
 popd 2>&1 >/dev/null
 

--- a/test/link/.link
+++ b/test/link/.link
@@ -20,17 +20,17 @@ recurse () {
     done
 }
 
-$HOME/.hermit/bin/hermit init $TEST_PROFILE_NAME
+$HERMIT_ROOT/bin/hermit init $TEST_PROFILE_NAME
 
 FIXTURE_NAME="$1"
 
 # Copy everything from the fixture into the newly created profile
-cp -r .fixtures/"$FIXTURE_NAME"/* $HOME/.hermit/profiles/$TEST_PROFILE_NAME
+cp -r .fixtures/"$FIXTURE_NAME"/* $HERMIT_ROOT/$PROFILE_DIR_NAME/$TEST_PROFILE_NAME
 
 CHECK_BASE="$HOME/"
 
 # Attempt the link
-$HOME/.hermit/bin/hermit link
+$HERMIT_ROOT/bin/hermit link
 
 # Check the fixture directory recursively
 recurse "$PWD/.fixtures/$FIXTURE_NAME"

--- a/test/setup_dir
+++ b/test/setup_dir
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-fixtures=$(ls link/.fixtures)
+fixtures=$(ls link/.fixtures 2> /dev/null)
 
 for fixture in $fixtures
 do

--- a/test/teardown_dir
+++ b/test/teardown_dir
@@ -2,5 +2,5 @@
 
 fixtures=$(cat .clean-tests)
 
-rm $fixtures
+rm $fixtures 2> /dev/null
 rm .clean-tests

--- a/test/unlink/sanity-check
+++ b/test/unlink/sanity-check
@@ -2,13 +2,13 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit init
+$HERMIT_ROOT/bin/hermit init
 
 FILE=.testfile
 
 touch $HOME/$FILE
 
-$HOME/.hermit/bin/hermit add $HOME/$FILE
+$HERMIT_ROOT/bin/hermit add $HOME/$FILE
 
-$HOME/.hermit/bin/hermit link
-$HOME/.hermit/bin/hermit unlink
+$HERMIT_ROOT/bin/hermit link
+$HERMIT_ROOT/bin/hermit unlink

--- a/test/use/sanity-check
+++ b/test/use/sanity-check
@@ -2,15 +2,15 @@
 
 source ../.environment
 
-$HOME/.hermit/bin/hermit init
+$HERMIT_ROOT/bin/hermit init
 
 FILE=.testfile
 
 touch $HOME/$FILE
 
-$HOME/.hermit/bin/hermit add $HOME/$FILE
+$HERMIT_ROOT/bin/hermit add $HOME/$FILE
 
-$HOME/.hermit/bin/hermit link # This is wrong. The flow should *not*
+$HERMIT_ROOT/bin/hermit link # This is wrong. The flow should *not*
                               # be that you init, add, and then need
                               # to explicitly link your profile
-$HOME/.hermit/bin/hermit use default
+$HERMIT_ROOT/bin/hermit use default

--- a/test/use/sanity-check
+++ b/test/use/sanity-check
@@ -10,7 +10,4 @@ touch $HOME/$FILE
 
 $HERMIT_ROOT/bin/hermit add $HOME/$FILE
 
-$HERMIT_ROOT/bin/hermit link # This is wrong. The flow should *not*
-                              # be that you init, add, and then need
-                              # to explicitly link your profile
-$HERMIT_ROOT/bin/hermit use default
+$HERMIT_ROOT/bin/hermit ${USE_COMMAND} default


### PR DESCRIPTION
Fixes #157 

This also required adding a helper subcommand for both sh hermit and rs hermit for printing out the currently active profile, and modifying rs hermit's `init` command to actually set the current shell like sh hermit did.

So the purpose is already working!  Also, having integration tests that exercise the main function dispatching and that the `handle_*` functions are properly implemented is great too.

The only thing we need to watch out for is if the behavior specified for a subcommand is bad/wrong and should be changed.