### PR TITLE
Fix installing tarpaulin on stable and beta channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache: cargo
 
 before_script:
   - cargo +nightly clippy --version || ( rustup install nightly && rustup component add clippy-preview --toolchain=nightly )
-  - cargo tarpaulin --version || RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
+  - cargo tarpaulin --version || RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo +nightly install cargo-tarpaulin
   - curl -o /tmp/urchin https://raw.githubusercontent.com/tlevine/urchin/v0.0.6/urchin && chmod +x /tmp/urchin
   - git fetch --unshallow
   - git config remote.$(git remote | head -n1).fetch "+refs/heads/*:refs/remotes/$(git remote | head -n1)/*"
@@ -26,7 +26,7 @@ script:
 
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
+    cargo +nightly tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
   fi
 
 addons:


### PR DESCRIPTION
Fixes the build.  cargo-tarpaulin recently became a nightly only crate, so trying to install it on stable and beta channels was failing and halting the build.